### PR TITLE
Infra: Remove dependencies on bintray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,6 @@ talaiot {
 
 allprojects {
     repositories {
-        jcenter()
         mavenCentral()
     }
     configureDiktat()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,11 @@ talaiot {
 allprojects {
     repositories {
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven") {  // detekt requires kotlinx.html
+            content {
+                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+            }
+        }
     }
     configureDiktat()
     configureDetekt()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 repositories {
     gradlePluginPortal()
     mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven")  // detekt requires kotlinx.html
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 repositories {
-    jcenter()
     gradlePluginPortal()
+    mavenCentral()
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -28,7 +28,7 @@ object Versions {
     const val okhttp3 = "4.9.1"
 
     // frontend
-    const val react = "17.0.1"
-    const val kotlinJsWrappersSuffix = "-pre.148-kotlin-1.4.30"
+    const val react = "17.0.2"
+    const val kotlinJsWrappersSuffix = "-pre.153-kotlin-1.4.32"
     const val kotlinReact = "$react$kotlinJsWrappersSuffix"
 }

--- a/save-common/build.gradle.kts
+++ b/save-common/build.gradle.kts
@@ -12,10 +12,6 @@ kotlin {
         annotation("org.springframework.stereotype.Service")
     }
 
-    repositories {
-        maven(url = "https://kotlin.bintray.com/kotlinx/") // it is used for datetime. In future updates it will be jcenter()
-    }
-
     jvm {
         compilations.all {
             kotlinOptions {

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -6,8 +6,9 @@ kotlin {
     js(LEGACY) {  // as for `-pre.148-kotlin-1.4.21`, react-table gives errors with IR
         browser {
             repositories {
-                jcenter()
-                maven("https://kotlin.bintray.com/js-externals")
+                mavenCentral()
+                maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers/")
+                maven("https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven")
             }
         }
         binaries.executable()  // already default for LEGACY, but explicitly needed for IR

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -83,7 +83,7 @@ class App : RComponent<RProps, AppState>() {
                                 attrs.executionId = props.match.params.executionId
                             }
                         }
-                        route("*", FallbackView::class)
+                        route("*", component = FallbackView::class)
                     }
                 }
                 child(Footer::class) {}

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -19,10 +19,6 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-repositories {
-    maven(url = "https://kotlin.bintray.com/kotlinx/") // it is used for datetime. In future updates it will be jcenter()
-}
-
 dependencies {
     api(project(":save-common"))
     implementation(project(":save-agent", "distribution"))


### PR DESCRIPTION
### What's done:
* Switched frontend from bintray to kotlin space
* Bump kotlin-js-wrappers version
* Fixed App.kt
* Removed bintray repo for kotlinx.datetime
* Removed jcenter repository from buildSrc and root build.gradle.kts

Bintray will be shut down soon, need to remove it from project dependencies. All of our dependencies have already migrated, so it's safe.