### PR TITLE
Orchestrator: Fixes for agents shutdown logic

### DIFF
--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -99,7 +99,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinTest> {
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-    outputs.file(versionsFile)
+//    inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
+//    outputs.file(versionsFile)
 
     doFirst {
         versionsFile.parentFile.mkdirs()

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -99,8 +99,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinTest> {
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-//    inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
-//    outputs.file(versionsFile)
+    // inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
+    // outputs.file(versionsFile)
 
     doFirst {
         versionsFile.parentFile.mkdirs()

--- a/save-agent/build.gradle.kts
+++ b/save-agent/build.gradle.kts
@@ -99,8 +99,10 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinTest> {
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-    // inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
-    // outputs.file(versionsFile)
+    val saveCliVersion = getSaveCliVersion()
+    inputs.property("Version of save-cli", saveCliVersion)
+    inputs.property("project version", version.toString())
+    outputs.file(versionsFile)
 
     doFirst {
         versionsFile.parentFile.mkdirs()
@@ -108,7 +110,7 @@ val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
             """
             package generated
 
-            internal const val SAVE_CORE_VERSION = "${getSaveCliVersion()}"
+            internal const val SAVE_CORE_VERSION = "$saveCliVersion"
             internal const val SAVE_CLOUD_VERSION = "$version"
 
             """.trimIndent()

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/AgentConfiguration.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/AgentConfiguration.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.Serializable
  * @property executionDataRetryAttempts number of retries when sending execution data
  * @property executionDataInitialRetryMillis interval between successive attempts to send execution data
  * @property cliCommand a command that agent will use to run SAVE cli
+ * @property debug whether debug logging should be enabled
  */
 @Serializable
 data class AgentConfiguration(

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/AgentConfiguration.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/AgentConfiguration.kt
@@ -30,6 +30,7 @@ data class AgentConfiguration(
     val requestTimeoutMillis: Long,
     val executionDataRetryAttempts: Int,
     val executionDataInitialRetryMillis: Long,
+    val debug: Boolean = false,
     val cliCommand: String = "./save-$SAVE_CORE_VERSION-linuxX64.kexe",
 )
 

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -3,6 +3,8 @@
 package org.cqfn.save.agent
 
 import org.cqfn.save.agent.utils.readFile
+import org.cqfn.save.core.logging.isDebugEnabled
+import org.cqfn.save.core.logging.logDebug
 import org.cqfn.save.core.logging.logError
 import org.cqfn.save.core.logging.logInfo
 import org.cqfn.save.core.utils.ExecutionResult
@@ -32,8 +34,6 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
-import org.cqfn.save.core.logging.isDebugEnabled
-import org.cqfn.save.core.logging.logDebug
 
 /**
  * A main class for SAVE Agent

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import org.cqfn.save.core.logging.isDebugEnabled
 
 /**
  * A main class for SAVE Agent
@@ -64,6 +65,7 @@ class SaveAgent(private val config: AgentConfiguration,
      * @return Unit
      */
     suspend fun start() = coroutineScope {
+        isDebugEnabled = config.debug
         logInfo("Starting agent")
         val heartbeatsJob = launch { startHeartbeats() }
         heartbeatsJob.join()

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -33,6 +33,7 @@ import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import org.cqfn.save.core.logging.isDebugEnabled
+import org.cqfn.save.core.logging.logDebug
 
 /**
  * A main class for SAVE Agent
@@ -115,6 +116,8 @@ class SaveAgent(private val config: AgentConfiguration,
         // blocking execution of OS process
         state.value = AgentState.BUSY
         val executionResult = runSave(cliArgs)
+        logDebug("Executed SAVE, here is stdout: ${executionResult.stdout}")
+        logDebug("Executed SAVE, here is stderr: ${executionResult.stderr}")
         val executionLogs = ExecutionLogs(config.id, readFile(logFilePath))
         val logsSending = launch {
             runCatching {

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -150,8 +150,8 @@ class SaveAgent(private val config: AgentConfiguration,
         logsSending.join()
     }
 
-    private fun runSave(cliArgs: String): ExecutionResult =
-            ProcessBuilder(true).exec(config.cliCommand.let { if (cliArgs.isNotEmpty()) "$it $cliArgs" else it }, logFilePath.toPath())
+    private fun runSave(cliArgs: String): ExecutionResult = ProcessBuilder(true)
+        .exec(config.cliCommand.let { if (cliArgs.isNotEmpty()) "$it $cliArgs" else it }, logFilePath.toPath())
 
     /**
      * @param executionLogs logs of CLI execution progress that will be sent in a message

--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -11,7 +11,7 @@ import org.cqfn.save.core.utils.ExecutionResult
 import org.cqfn.save.core.utils.ProcessBuilder
 import org.cqfn.save.domain.TestResultStatus
 
-import generated.SAVE_CORE_VERSION
+import generated.SAVE_CLOUD_VERSION
 import io.ktor.client.HttpClient
 import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.json.JsonFeature
@@ -213,6 +213,6 @@ class SaveAgent(private val config: AgentConfiguration,
     private suspend fun saveAdditionalData() = httpClient.post<HttpResponse> {
         url("${config.backendUrl}/saveAgentVersion")
         contentType(ContentType.Application.Json)
-        body = AgentVersion(config.id, SAVE_CORE_VERSION)
+        body = AgentVersion(config.id, SAVE_CLOUD_VERSION)
     }
 }

--- a/save-agent/src/nativeMain/resources/agent.properties
+++ b/save-agent/src/nativeMain/resources/agent.properties
@@ -5,3 +5,4 @@ heartbeat.interval=15000
 requestTimeoutMillis=1000
 executionDataRetryAttempts=5
 executionDataInitialRetryMillis=1000
+debug=true

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
@@ -6,6 +6,7 @@ import org.cqfn.save.backend.repository.AgentStatusRepository
 import org.cqfn.save.entities.Agent
 import org.cqfn.save.entities.AgentStatus
 import org.cqfn.save.entities.AgentStatusDto
+import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.entities.Execution
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
@@ -81,12 +82,20 @@ class AgentsController(private val agentStatusRepository: AgentStatusRepository,
      */
     @GetMapping("/getAgentsStatusesForSameExecution")
     @Transactional
-    fun findAllAgentStatusesForSameExecution(@RequestParam agentId: String): List<AgentStatusDto?> =
-            agentRepository.findAll { root, cq, cb ->
-                cb.equal(root.get<Execution>("execution"), getAgentByContainerId(agentId).execution)
-            }.map {
-                agentStatusRepository.findTopByAgentContainerIdOrderByEndTimeDesc(it.containerId)?.toDto()
+    fun findAllAgentStatusesForSameExecution(@RequestParam agentId: String): AgentStatusesForExecution {
+        val execution = getAgentByContainerId(agentId).execution
+        val agentStatuses = agentRepository.findAll { root, cq, cb ->
+            cb.equal(root.get<Execution>("execution"), execution)
+        }.map { agent ->
+            val latestStatus = requireNotNull(
+                agentStatusRepository.findTopByAgentContainerIdOrderByEndTimeDesc(agent.containerId)
+            ) {
+                "AgentStatus not found for agent id=${agent.containerId}"
             }
+            latestStatus.toDto()
+        }
+        return AgentStatusesForExecution(execution.id!!, agentStatuses)
+    }
 
     /**
      * Get agent by containerId.

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
@@ -82,6 +82,7 @@ class AgentsController(private val agentStatusRepository: AgentStatusRepository,
      */
     @GetMapping("/getAgentsStatusesForSameExecution")
     @Transactional
+    @Suppress("UnsafeCallOnNullableType")  // id will be available because it's retrieved from DB
     fun findAllAgentStatusesForSameExecution(@RequestParam agentId: String): AgentStatusesForExecution {
         val execution = getAgentByContainerId(agentId).execution
         val agentStatuses = agentRepository.findAll { root, cq, cb ->

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
@@ -20,7 +20,9 @@ class TestSuitesService {
      * @return list of TestSuites
      */
     fun saveTestSuite(testSuitesDto: List<TestSuiteDto>): List<TestSuite> {
-        val testSuites = testSuitesDto.map { TestSuite(it.type, it.name, it.project, LocalDateTime.now(), "save.properties") }
+        val testSuites = testSuitesDto.map {
+            TestSuite(it.type, it.name, it.project, LocalDateTime.now(), it.propertiesRelativePath)
+        }
         testSuiteRepository.saveAll(testSuites)
         return testSuites
     }

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/AgentsControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/AgentsControllerTest.kt
@@ -8,6 +8,7 @@ import org.cqfn.save.backend.repository.AgentStatusRepository
 import org.cqfn.save.backend.utils.MySqlExtension
 import org.cqfn.save.entities.AgentStatus
 import org.cqfn.save.entities.AgentStatusDto
+import org.cqfn.save.entities.AgentStatusesForExecution
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -126,13 +127,12 @@ class AgentsControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
-            .expectBody<List<AgentStatusDto?>>()
+            .expectBody<AgentStatusesForExecution>()
             .consumeWith {
-                val statuses = it.responseBody
-                requireNotNull(statuses)
+                val statuses = requireNotNull(it.responseBody).agentStatuses
                 Assertions.assertEquals(2, statuses.size)
-                Assertions.assertEquals(AgentState.IDLE, statuses.first()!!.state)
-                Assertions.assertEquals(AgentState.BUSY, statuses[1]!!.state)
+                Assertions.assertEquals(AgentState.IDLE, statuses.first().state)
+                Assertions.assertEquals(AgentState.BUSY, statuses[1].state)
             }
     }
 
@@ -151,7 +151,7 @@ class AgentsControllerTest {
         Assertions.assertEquals(agentRepository.findByContainerId(agentVersion.containerId)?.version, agentVersion.version)
     }
 
-    private fun updateAgentStatuses(body: Any) {
+    private fun updateAgentStatuses(body: List<AgentStatusDto>) {
         webTestClient
             .method(HttpMethod.POST)
             .uri("/updateAgentStatusesWithDto")

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/AgentStatus.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/AgentStatus.kt
@@ -42,8 +42,19 @@ class AgentStatus(
  * @property containerId id of the agent's container
  * @property time
  */
-class AgentStatusDto(
+data class AgentStatusDto(
     val time: LocalDateTime,
     val state: AgentState,
     val containerId: String,
+)
+
+/**
+ * Statuses of a group of agents for a single Execution
+ *
+ * @property executionId id of Execution
+ * @property agentStatuses list of [AgentStatusDto]s
+ */
+data class AgentStatusesForExecution(
+    val executionId: Long,
+    val agentStatuses: List<AgentStatusDto>,
 )

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
+    inputs.property("project version", version.toString())
     outputs.file(versionsFile)
 
     doFirst {

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -56,8 +56,10 @@ configureJacoco()
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-    // inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
-    // outputs.file(versionsFile)
+    val saveCliVersion = getSaveCliVersion()
+    inputs.property("Version of save-cli", saveCliVersion)
+    inputs.property("project version", version.toString())
+    outputs.file(versionsFile)
 
     doFirst {
         versionsFile.parentFile.mkdirs()

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -56,7 +56,8 @@ configureJacoco()
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-    outputs.file(versionsFile)
+//    inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
+//    outputs.file(versionsFile)
 
     doFirst {
         versionsFile.parentFile.mkdirs()

--- a/save-orchestrator/build.gradle.kts
+++ b/save-orchestrator/build.gradle.kts
@@ -56,8 +56,8 @@ configureJacoco()
 val generateVersionFileTaskProvider = tasks.register("generateVersionFile") {
     val versionsFile = File("$buildDir/generated/src/generated/Versions.kt")
 
-//    inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
-//    outputs.file(versionsFile)
+    // inputs.property("saveCliVersion", null)  // todo is it correct? will it run when property is not set?
+    // outputs.file(versionsFile)
 
     doFirst {
         versionsFile.parentFile.mkdirs()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/SaveOrchestrator.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/SaveOrchestrator.kt
@@ -4,6 +4,7 @@ import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.http.ResponseEntity
 import org.springframework.web.reactive.config.EnableWebFlux
 
 /**
@@ -13,6 +14,8 @@ import org.springframework.web.reactive.config.EnableWebFlux
 @EnableWebFlux
 @EnableConfigurationProperties(ConfigProperties::class)
 open class SaveOrchestrator
+
+internal typealias BodilessResponseEntity = ResponseEntity<Void>
 
 fun main(args: Array<String>) {
     SpringApplication.run(SaveOrchestrator::class.java, *args)

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -81,9 +81,10 @@ class HeartbeatController(private val agentService: AgentService,
         agentService.getAgentsAwaitingStop(agentId).doOnSuccess { (executionId, finishedAgentIds) ->
             scheduler.schedule {
                 if (finishedAgentIds.isNotEmpty()) {
-                    logger.info("Agents ids=$finishedAgentIds have completed execution, will make an attempt to terminate them")
+                    logger.debug("Agents ids=$finishedAgentIds have completed execution, will make an attempt to terminate them")
                     val areAgentsStopped = dockerService.stopAgents(finishedAgentIds)
                     if (areAgentsStopped) {
+                        logger.info("Agents have been stopped, will mark execution id=$executionId and agents $finishedAgentIds as FINISHED")
                         agentService
                             .markAgentsAndExecutionAsFinished(executionId, finishedAgentIds)
                             .block()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -52,16 +52,10 @@ class HeartbeatController(private val agentService: AgentService,
         )
             .then(
                 when (heartbeat.state) {
-                    AgentState.IDLE -> agentService.getNewTestsIds(heartbeat.agentId).subscribeOn(scheduler)
+                    AgentState.IDLE -> agentService.getNewTestsIds(heartbeat.agentId)
                         .doOnSuccess {
                             if (it is WaitResponse) {
-                                // If agent was IDLE and there are no new tests - we check if the Execution is completed.
-                                agentService.getAgentsAwaitingStop(heartbeat.agentId).subscribeOn(scheduler).subscribe { finishedAgentIds ->
-                                    if (finishedAgentIds.isNotEmpty()) {
-                                        logger.info("Agents ids=$finishedAgentIds have completed execution and will be terminated")
-                                        dockerService.stopAgents(finishedAgentIds)
-                                    }
-                                }
+                                initiateShutdownSequence(heartbeat.agentId)
                             }
                         }
                     AgentState.FINISHED -> {
@@ -74,5 +68,30 @@ class HeartbeatController(private val agentService: AgentService,
                     AgentState.CLI_FAILED -> Mono.just(WaitResponse)
                 }
             )
+    }
+
+    /**
+     * If agent was IDLE and there are no new tests - we check if the Execution is completed.
+     * We get all agents for the same execution, if they are all done.
+     * Then we stop them via DockerService and update necessary statuses in DB via AgentService.
+     *
+     * @param agentId an ID of the agent from the execution, that will be checked.
+     */
+    private fun initiateShutdownSequence(agentId: String) {
+        agentService.getAgentsAwaitingStop(agentId).doOnSuccess { (executionId, finishedAgentIds) ->
+            scheduler.schedule {
+                if (finishedAgentIds.isNotEmpty()) {
+                    logger.info("Agents ids=$finishedAgentIds have completed execution, will make an attempt to terminate them")
+                    val areAgentsStopped = dockerService.stopAgents(finishedAgentIds)
+                    if (areAgentsStopped) {
+                        agentService
+                            .markAgentsAndExecutionAsFinished(executionId, finishedAgentIds)
+                            .block()
+                    }
+                }
+            }
+        }
+            .subscribeOn(scheduler)
+            .subscribe()
     }
 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -126,18 +126,19 @@ class AgentService(configProperties: ConfigProperties) {
      * @param finishedAgentIds agents that should be updated
      * @return a bodiless response entity
      */
-    fun markAgentsAndExecutionAsFinished(executionId: Long, finishedAgentIds: List<String>): Mono<BodilessResponseEntity> = updateAgentStatusesWithDto(
-        finishedAgentIds.map { agentId ->
-            AgentStatusDto(LocalDateTime.now(), AgentState.FINISHED, agentId)
-        }
-    )
-        .then(
-            webClientBackend.post()
-                .uri("/updateExecution")
-                .bodyValue(ExecutionUpdateDto(executionId, ExecutionStatus.FINISHED))  // todo: status based on results
-                .retrieve()
-                .toBodilessEntity()
-        )
+    fun markAgentsAndExecutionAsFinished(executionId: Long, finishedAgentIds: List<String>): Mono<BodilessResponseEntity> =
+            updateAgentStatusesWithDto(
+                finishedAgentIds.map { agentId ->
+                    AgentStatusDto(LocalDateTime.now(), AgentState.FINISHED, agentId)
+                }
+            )
+                .then(
+                    webClientBackend.post()
+                        .uri("/updateExecution")
+                        .bodyValue(ExecutionUpdateDto(executionId, ExecutionStatus.FINISHED))  // todo: status based on results
+                        .retrieve()
+                        .toBodilessEntity()
+                )
 
     /**
      * Get list of agent ids (containerIds) for agents that have completed their jobs.

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -10,12 +10,12 @@ import org.cqfn.save.entities.AgentStatusDto
 import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
+import org.cqfn.save.orchestrator.BodilessResponseEntity
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.test.TestBatch
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -97,7 +97,7 @@ class AgentService(configProperties: ConfigProperties) {
      * @param agentStates list of [AgentStatus]es to update in the DB
      * @return as bodiless entity of response
      */
-    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<ResponseEntity<Void>> =
+    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<BodilessResponseEntity> =
             webClientBackend
                 .post()
                 .uri("/updateAgentStatusesWithDto")
@@ -126,7 +126,7 @@ class AgentService(configProperties: ConfigProperties) {
      * @param finishedAgentIds agents that should be updated
      * @return a bodiless response entity
      */
-    fun markAgentsAndExecutionAsFinished(executionId: Long, finishedAgentIds: List<String>): Mono<ResponseEntity<Void>> = updateAgentStatusesWithDto(
+    fun markAgentsAndExecutionAsFinished(executionId: Long, finishedAgentIds: List<String>): Mono<BodilessResponseEntity> = updateAgentStatusesWithDto(
         finishedAgentIds.map { agentId ->
             AgentStatusDto(LocalDateTime.now(), AgentState.FINISHED, agentId)
         }
@@ -145,6 +145,7 @@ class AgentService(configProperties: ConfigProperties) {
      * @param agentId containerId of an agent
      * @return Mono with list of agent ids for agents that can be shut down.
      */
+    @Suppress("TYPE_ALIAS")
     fun getAgentsAwaitingStop(agentId: String): Mono<Pair<Long, List<String>>> {
         // If we call this method, then there are no unfinished TestExecutions.
         // check other agents status

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -7,11 +7,15 @@ import org.cqfn.save.agent.WaitResponse
 import org.cqfn.save.entities.Agent
 import org.cqfn.save.entities.AgentStatus
 import org.cqfn.save.entities.AgentStatusDto
+import org.cqfn.save.entities.AgentStatusesForExecution
+import org.cqfn.save.execution.ExecutionStatus
+import org.cqfn.save.execution.ExecutionUpdateDto
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.test.TestBatch
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
@@ -91,8 +95,9 @@ class AgentService(configProperties: ConfigProperties) {
 
     /**
      * @param agentStates list of [AgentStatus]es to update in the DB
+     * @return as bodiless entity of response
      */
-    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>) =
+    fun updateAgentStatusesWithDto(agentStates: List<AgentStatusDto>): Mono<ResponseEntity<Void>> =
             webClientBackend
                 .post()
                 .uri("/updateAgentStatusesWithDto")
@@ -115,21 +120,41 @@ class AgentService(configProperties: ConfigProperties) {
     }
 
     /**
+     * Marks agent states and then execution state as FINISHED
+     *
+     * @param executionId execution that should be updated
+     * @param finishedAgentIds agents that should be updated
+     * @return a bodiless response entity
+     */
+    fun markAgentsAndExecutionAsFinished(executionId: Long, finishedAgentIds: List<String>): Mono<ResponseEntity<Void>> = updateAgentStatusesWithDto(
+        finishedAgentIds.map { agentId ->
+            AgentStatusDto(LocalDateTime.now(), AgentState.FINISHED, agentId)
+        }
+    )
+        .then(
+            webClientBackend.post()
+                .uri("/updateExecution")
+                .bodyValue(ExecutionUpdateDto(executionId, ExecutionStatus.FINISHED))  // todo: status based on results
+                .retrieve()
+                .toBodilessEntity()
+        )
+
+    /**
      * Get list of agent ids (containerIds) for agents that have completed their jobs.
      *
      * @param agentId containerId of an agent
      * @return Mono with list of agent ids for agents that can be shut down.
      */
-    fun getAgentsAwaitingStop(agentId: String): Mono<List<String>> {
+    fun getAgentsAwaitingStop(agentId: String): Mono<Pair<Long, List<String>>> {
         // If we call this method, then there are no unfinished TestExecutions.
         // check other agents status
         return webClientBackend
             .get()
             .uri("/getAgentsStatusesForSameExecution?agentId=$agentId")
             .retrieve()
-            .bodyToMono<List<AgentStatusDto>>()
-            .map { agentStatuses ->
-                if (agentStatuses.all { it.state == AgentState.IDLE }) {
+            .bodyToMono<AgentStatusesForExecution>()
+            .map { (executionId, agentStatuses) ->
+                executionId to if (agentStatuses.all { it.state == AgentState.IDLE }) {
                     agentStatuses.map { it.containerId }
                 } else {
                     emptyList()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -91,7 +91,7 @@ class DockerService(private val configProperties: ConfigProperties) {
         isAgentStoppingInProgress.lazySet(false)
         true
     } else {
-        log.info("Agents stopping is already in progress, skipping")
+        log.debug("Agents stopping is already in progress, skipping")
         false
     }
 

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -89,6 +89,8 @@ class DockerService(private val configProperties: ConfigProperties) {
                 log.info("Agent with id=$it has been stopped")
             }
             isAgentStoppingInProgress.lazySet(false)
+        } else {
+            log.info("Agents stopping is already in progress, skipping")
         }
     }
 

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -143,6 +144,7 @@ class HeartbeatControllerTest {
 
     @Test
     fun `should shutdown idle agents when there are no tests left`() {
+        whenever(dockerService.stopAgents(any())).thenReturn(true)
         testHeartbeat(
             agentStatusDtos = listOf(
                 AgentStatusDto(LocalDateTime.now(), AgentState.IDLE, "test-1"),
@@ -151,6 +153,17 @@ class HeartbeatControllerTest {
             heartbeat = Heartbeat("test-1", AgentState.IDLE, ExecutionProgress(100)),
             testBatch = TestBatch(emptyList(), emptyMap()),
             mockAgentStatuses = true,
+            {
+                // additional setup for marking stuff as FINISHED
+                // /updateAgentStatuses
+                mockServer.enqueue(
+                    MockResponse().setResponseCode(200)
+                )
+                // /updateExecution
+                mockServer.enqueue(
+                    MockResponse().setResponseCode(200)
+                )
+            }
         ) {
             verify(dockerService, times(1)).stopAgents(any())
         }
@@ -159,19 +172,21 @@ class HeartbeatControllerTest {
     /**
      * Test logic triggered by a heartbeat.
      *
-     * @param agentStatuses agent statuses that are returned from backend (mocked response)
+     * @param agentStatusDtos agent statuses that are returned from backend (mocked response)
      * @param heartbeat a [Heartbeat] that is received by orchestrator
-     * @param tests a batch of tests returned from backend (mocked response)
+     * @param testBatch a batch of tests returned from backend (mocked response)
      * @param mockAgentStatuses whether a mocked response for `/getAgentsStatusesForSameExecution` should be added to queue
+     * @param additionalSetup is executed before the request is performed
      * @param verification a lambda for test assertions
      */
     @OptIn(ExperimentalStdlibApi::class)
-    @Suppress("TOO_LONG_FUNCTION")
+    @Suppress("TOO_LONG_FUNCTION", "TOO_MANY_PARAMETERS", "LongParameterList")
     private fun testHeartbeat(
         agentStatusDtos: List<AgentStatusDto>,
         heartbeat: Heartbeat,
         testBatch: TestBatch,
         mockAgentStatuses: Boolean = false,
+        additionalSetup: () -> Unit = {},
         verification: () -> Unit,
     ) {
         // /updateAgentStatuses
@@ -196,6 +211,7 @@ class HeartbeatControllerTest {
                     .addHeader("Content-Type", "application/json")
             )
         }
+        additionalSetup()
         val assertions = CompletableFuture.supplyAsync {
             buildList<RecordedRequest?> {
                 mockServer.takeRequest(60, TimeUnit.SECONDS)

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -5,6 +5,7 @@ import org.cqfn.save.agent.ExecutionProgress
 import org.cqfn.save.agent.Heartbeat
 import org.cqfn.save.agent.NewJobResponse
 import org.cqfn.save.entities.AgentStatusDto
+import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.orchestrator.config.Beans
 import org.cqfn.save.orchestrator.service.AgentService
 import org.cqfn.save.orchestrator.service.DockerService
@@ -188,7 +189,9 @@ class HeartbeatControllerTest {
             mockServer.enqueue(
                 MockResponse()
                     .setBody(
-                        objectMapper.writeValueAsString(agentStatusDtos)
+                        objectMapper.writeValueAsString(
+                            AgentStatusesForExecution(0, agentStatusDtos)
+                        )
                     )
                     .addHeader("Content-Type", "application/json")
             )

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
@@ -14,6 +14,7 @@ import org.cqfn.save.testsuite.TestSuiteType
 
 import okio.ExperimentalFileSystem
 import okio.Path.Companion.toPath
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 /**
@@ -81,6 +82,13 @@ class TestDiscoveringService {
                     TestDto(it.first().toString(), testSuite.id!!, it.first().toFile().toHash())
                 }
         }
+        .also {
+            log.debug("Discovered the following tests: $it")
+        }
 
     private fun TestConfig.getGeneralConfigOrNull() = pluginConfigs.filterIsInstance<GeneralConfig>().singleOrNull()
+
+    companion object {
+        private val log = LoggerFactory.getLogger(TestDiscoveringService::class.java)
+    }
 }

--- a/save-preprocessor/src/main/resources/application.properties
+++ b/save-preprocessor/src/main/resources/application.properties
@@ -4,3 +4,4 @@ save.repository=/home/cnb/repositories/
 save.backend=http://backend:5000
 save.orchestrator=http://orchestrator:5100
 save.executionLimit=20
+logging.level.org.cqfn.save.preprocessor.service.TestDiscoveringService=DEBUG


### PR DESCRIPTION
### What's done:
* Execution and AgentsStatus are marked as FINISHED after agents shutdown
* Enabled debug for save-agent
* Fix property file path in backend saveTestSuite
* Added inputs for code generation tasks in gradle
* Added more logging for TestDiscoveringService, enabled debug logging in application.properties
* Publish agent's version instead of cli version

Closes #145