### PR TITLE
Change reactor-netty configuration parameters

### DIFF
--- a/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/SpringBootConfiguration.kt
+++ b/buildSrc/src/main/kotlin/org/cqfn/save/buildutils/SpringBootConfiguration.kt
@@ -68,7 +68,11 @@ fun Project.configureSpringBoot(withSpringDataJpa: Boolean = false) {
         dependsOn(rootProject.tasks.getByName("startLocalDockerRegistry"))
         // `host.docker.internal` for win 10?
         imageName = "127.0.0.1:6000/${project.name}:${project.versionForDockerImages()}"
-        environment = mapOf("BP_JVM_VERSION" to Versions.BP_JVM_VERSION)
+        environment = mapOf(
+            "BP_JVM_VERSION" to Versions.BP_JVM_VERSION,
+            "BPE_DELIM_JAVA_TOOL_OPTIONS" to " ",
+            "BPE_APPEND_JAVA_TOOL_OPTIONS" to "-Dreactor.netty.pool.maxIdleTime=60000 -Dreactor.netty.pool.leasingStrategy=lifo"
+        )
         isPublish = false
     }
 }


### PR DESCRIPTION
### What's done:
* Use LIFO leasing strategy and max idle timeout for netty connection pool

Possible fix for `readAddress(..) failed: Connection reset by peer`. According to https://github.com/reactor/reactor-netty/issues/564, these options should fix the error. It seems, that docker environent is closing idle connections from netty's pool after some time. Anyway, after these options have been enabled, I haven't observed the issue, which would randomly occur the day before.

Closes #150 