### PR TITLE
Improve frontend bundle packaging and size

### DIFF
--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
             compileOnly(devNpm("postcss-loader", "3.*"))
             compileOnly(devNpm("postcss", "7.*"))
             compileOnly(devNpm("autoprefixer", "9.*"))
+            compileOnly(devNpm("webpack-bundle-analyzer", "*"))
 
             // web-specific dependencies
             implementation(npm("@fortawesome/fontawesome-svg-core", "1.2.35"))

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -28,7 +28,9 @@ kotlin {
             compileOnly(devNpm("file-loader", "*"))
 
             // web-specific dependencies
-            compileOnly(npm("@fortawesome/fontawesome-free", "5.15.1"))  // needed to copy fonts to resources, not needed in runtime
+            implementation(npm("@fortawesome/fontawesome-svg-core", "1.2.35"))
+            implementation(npm("@fortawesome/free-solid-svg-icons", "5.15.3"))
+            implementation(npm("@fortawesome/react-fontawesome", "0.1.14"))
             implementation("org.jetbrains:kotlin-react:${Versions.kotlinReact}")
             implementation("org.jetbrains:kotlin-react-dom:${Versions.kotlinReact}")
             implementation("org.jetbrains:kotlin-react-router-dom:5.2.0${Versions.kotlinJsWrappersSuffix}")

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -26,6 +26,10 @@ kotlin {
             compileOnly(devNpm("css-loader", "*"))
             compileOnly(devNpm("url-loader", "*"))
             compileOnly(devNpm("file-loader", "*"))
+            // these dependenceies are bound to postcss 7.x instead of 8.x, because bootstrap 4.x guide uses them
+            compileOnly(devNpm("postcss-loader", "3.*"))
+            compileOnly(devNpm("postcss", "7.*"))
+            compileOnly(devNpm("autoprefixer", "9.*"))
 
             // web-specific dependencies
             implementation(npm("@fortawesome/fontawesome-svg-core", "1.2.35"))

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -83,18 +83,10 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().forEach {
     it.dependsOn(generateVersionFileTaskProvider)
 }
 
-val copyWebfontsTaskProvider = tasks.register("copyWebfonts", Copy::class) {
-    // add fontawesome font into the build
-    dependsOn(rootProject.tasks.getByName("kotlinNpmInstall"))  // to have dependencies downloaded
-    from("$rootDir/build/js/node_modules/@fortawesome/fontawesome-free/webfonts")
-    into("$buildDir/processedResources/js/main/webfonts")
-}
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack>().forEach { kotlinWebpack ->
-    kotlinWebpack.dependsOn(copyWebfontsTaskProvider)
     kotlinWebpack.doFirst {
         val additionalWebpackResources = fileTree("$buildDir/processedResources/js/main/") {
             include("scss/**")
-            include("webfonts/**")
         }
         copy {
             from(additionalWebpackResources)
@@ -109,7 +101,7 @@ val distributionJarTask by tasks.registering(Jar::class) {
     archiveClassifier.set("distribution")
     from("$buildDir/distributions")
     into("static")
-    exclude("scss", "webfonts")
+    exclude("scss")
 }
 artifacts.add(distribution.name, distributionJarTask.get().archiveFile) {
     builtBy(distributionJarTask)

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -14,8 +14,13 @@ import org.cqfn.save.frontend.components.views.FallbackView
 import org.cqfn.save.frontend.components.views.HistoryView
 import org.cqfn.save.frontend.components.views.ProjectExecutionRouteProps
 import org.cqfn.save.frontend.components.views.ProjectView
+import org.cqfn.save.frontend.externals.fontawesome.faAngleUp
+import org.cqfn.save.frontend.externals.fontawesome.faCogs
+import org.cqfn.save.frontend.externals.fontawesome.faSignOutAlt
+import org.cqfn.save.frontend.externals.fontawesome.faUser
+import org.cqfn.save.frontend.externals.fontawesome.fas
+import org.cqfn.save.frontend.externals.fontawesome.library
 import org.cqfn.save.frontend.externals.modal.ReactModal
-import org.cqfn.save.frontend.utils.get
 
 import org.w3c.dom.HTMLElement
 import react.RBuilder
@@ -99,6 +104,7 @@ class App : RComponent<RProps, AppState>() {
 fun main() {
     kotlinext.js.require("../scss/save-frontend.scss")  // this is needed for webpack to include resource
     kotlinext.js.require("bootstrap")  // this is needed for webpack to include bootstrap
+    library.add(fas, faUser, faCogs, faSignOutAlt, faAngleUp)
     ReactModal.setAppElement(document.getElementById("wrapper") as HTMLElement)  // required for accessibility in react-modal
 
     render(document.getElementById("wrapper")) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/TopBar.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/TopBar.kt
@@ -5,6 +5,7 @@
 package org.cqfn.save.frontend.components
 
 import org.cqfn.save.frontend.components.modal.logoutModal
+import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
 
 import react.RBuilder
 import react.RComponent
@@ -14,7 +15,6 @@ import react.dom.RDOMBuilder
 import react.dom.a
 import react.dom.button
 import react.dom.div
-import react.dom.i
 import react.dom.img
 import react.dom.li
 import react.dom.nav
@@ -118,9 +118,9 @@ class TopBar : RComponent<TopBarProps, TopBarState>() {
                     // Dropdown - User Information
                     div("dropdown-menu dropdown-menu-right shadow animated--grow-in") {
                         attrs["aria-labelledby"] = "userDropdown"
-                        dropdownEntry("fa-user", "Profile")
-                        dropdownEntry("fa-cogs", "Settings")
-                        dropdownEntry("fa-sign-out-alt", "Log out") {
+                        dropdownEntry("user", "Profile")
+                        dropdownEntry("cogs", "Settings")
+                        dropdownEntry("sign-out-alt", "Log out") {
                             attrs.onClickFunction = {
                                 setState {
                                     isLogoutModalOpen = true
@@ -140,9 +140,11 @@ class TopBar : RComponent<TopBarProps, TopBarState>() {
 
     private fun RBuilder.dropdownEntry(faIcon: String, text: String, handler: RDOMBuilder<BUTTON>.() -> Unit = { }) =
             button(type = ButtonType.button, classes = "btn btn-no-outline dropdown-item rounded-0 shadow-none") {
-                i("fas $faIcon fa-sm fa-fw mr-2 text-gray-400") {
-                    +text
+                fontAwesomeIcon {
+                    attrs.icon = faIcon
+                    attrs.className = "fas fa-sm fa-fw mr-2 text-gray-400"
                 }
+                +text
                 handler(this)
             }
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/Card.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/Card.kt
@@ -6,10 +6,11 @@
 
 package org.cqfn.save.frontend.components.basic
 
+import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+
 import react.RProps
 import react.dom.RDOMBuilder
 import react.dom.div
-import react.dom.i
 import react.functionalComponent
 
 import kotlinx.html.DIV
@@ -56,7 +57,7 @@ fun cardComponent(contentBuilder: RDOMBuilder<DIV>.() -> Unit) = functionalCompo
                         }
                     }
                     div("col-auto") {
-                        i("fas ${props.faIcon} fa-2x text-gray-300") {}
+                        fontAwesomeIcon(icon = props.faIcon, classes = "fas fa-2x text-gray-300")
                     }
                 }
             }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/ScrollToTopButton.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/ScrollToTopButton.kt
@@ -4,12 +4,13 @@
 
 package org.cqfn.save.frontend.components.basic
 
+import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+
 import org.w3c.dom.SMOOTH
 import org.w3c.dom.ScrollBehavior
 import org.w3c.dom.ScrollToOptions
 import react.RProps
 import react.dom.a
-import react.dom.i
 import react.functionalComponent
 import react.useEffect
 import react.useState
@@ -38,7 +39,7 @@ fun scrollToTopButton() = functionalComponent<RProps> {
             attrs.onClickFunction = {
                 window.scrollTo(ScrollToOptions(top = 0.0, behavior = ScrollBehavior.SMOOTH))
             }
-            i("fas fa-angle-up") {}
+            fontAwesomeIcon(icon = "angle-up")
         }
     }
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FaSetup.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FaSetup.kt
@@ -1,0 +1,10 @@
+/**
+ * External declarations from fontawesome-svg-core
+ */
+
+@file:JsModule("@fortawesome/fontawesome-svg-core")
+@file:JsNonModule
+
+package org.cqfn.save.frontend.externals.fontawesome
+
+external val library: dynamic

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FontAusomeIconBuilders.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FontAusomeIconBuilders.kt
@@ -1,0 +1,31 @@
+/**
+ * kotlin-react builders for FontAwesomeIcon components
+ */
+
+package org.cqfn.save.frontend.externals.fontawesome
+
+import react.RBuilder
+import react.RHandler
+
+/**
+ * @param icon icon. Can be object, string or array.
+ * @param classes element's classes
+ * @return ReactElement
+ */
+fun RBuilder.fontAwesomeIcon(
+    icon: dynamic,
+    classes: String = ""
+) = child(FontAwesomeIcon::class) {
+    attrs.icon = icon
+    attrs.className = classes
+}
+
+/**
+ * @param handler handler to set up a component
+ * @return ReactElement
+ */
+fun RBuilder.fontAwesomeIcon(
+    handler: RHandler<FontAwesomeIconProps>
+) = child(FontAwesomeIcon::class) {
+    handler.invoke(this)
+}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FontAwesomeIcon.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FontAwesomeIcon.kt
@@ -1,0 +1,15 @@
+@file:JsModule("@fortawesome/react-fontawesome")
+@file:JsNonModule
+
+package org.cqfn.save.frontend.externals.fontawesome
+
+import react.Component
+import react.RState
+import react.ReactElement
+
+/**
+ * External declaration of [FontAwesomeIcon] react component
+ */
+external class FontAwesomeIcon : Component<FontAwesomeIconProps, RState> {
+    override fun render(): ReactElement?
+}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FontAwesomeIconProps.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/FontAwesomeIconProps.kt
@@ -1,0 +1,18 @@
+package org.cqfn.save.frontend.externals.fontawesome
+
+import react.RProps
+
+/**
+ * RProps of [FontAwesomeIcon]
+ */
+external interface FontAwesomeIconProps : RProps {
+    /**
+     * Icon. Can be object, string or array.
+     */
+    var icon: dynamic
+
+    /**
+     * Classes of the element
+     */
+    var className: String
+}

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/Icons.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/Icons.kt
@@ -1,0 +1,14 @@
+/**
+ * External declarations of icons from fontawesome-solid
+ */
+
+@file:JsModule("@fortawesome/free-solid-svg-icons")
+@file:JsNonModule
+
+package org.cqfn.save.frontend.externals.fontawesome
+
+external val fas: dynamic
+external val faUser: dynamic
+external val faCogs: dynamic
+external val faSignOutAlt: dynamic
+external val faAngleUp: dynamic

--- a/save-frontend/src/main/resources/index.html
+++ b/save-frontend/src/main/resources/index.html
@@ -20,5 +20,6 @@
 
 <!-- Kotlin/JS compiled script -->
 <script src="save-frontend.js"></script>
+<script src="save-frontend-vendors.js"></script>
 </body>
 </html>

--- a/save-frontend/src/main/resources/scss/_variables.scss
+++ b/save-frontend/src/main/resources/scss/_variables.scss
@@ -1,5 +1,3 @@
-$fa-font-path: "../webfonts";
-
 // Override Bootstrap default variables here
 
 // Color Variables

--- a/save-frontend/src/main/resources/scss/save-frontend.scss
+++ b/save-frontend/src/main/resources/scss/save-frontend.scss
@@ -3,8 +3,6 @@
 
 // Import npm dependencies; path will be resolved relative to node_modules in rootProject.buildDir (kotlin js plugin adds `resolve` directive to webpack config)
 @import "bootstrap/scss/bootstrap.scss";
-@import "@fortawesome/fontawesome-free/scss/fontawesome.scss";
-@import "@fortawesome/fontawesome-free/scss/solid.scss";
 
 // Import Custom SB Admin 2 Mixins and Components
 @import "mixins.scss";

--- a/save-frontend/webpack.config.d/css.js
+++ b/save-frontend/webpack.config.d/css.js
@@ -4,6 +4,17 @@ config.module.rules.push(
         use: [
             'style-loader', // creates style nodes from JS strings
             'css-loader', // translates CSS into CommonJS
+            {
+                loader: 'postcss-loader', // Run postcss actions
+                options: {
+                    // postcss plugins, can be exported to postcss.config.js
+                    plugins: function () {
+                        return [
+                            require('autoprefixer')
+                        ];
+                    }
+                }
+            },
             'sass-loader', // compiles Sass to CSS, using Node Sass by default
         ]
     },

--- a/save-frontend/webpack.config.d/optimizations.js
+++ b/save-frontend/webpack.config.d/optimizations.js
@@ -1,0 +1,11 @@
+config.optimization = {
+	splitChunks: {
+		cacheGroups: {
+			commons: {
+				test: /[\\/]node_modules[\\/]/,
+				name: 'vendors',
+				chunks: 'all'
+			}
+		}
+	}
+};

--- a/save-frontend/webpack.config.d/optimizations.js
+++ b/save-frontend/webpack.config.d/optimizations.js
@@ -1,4 +1,5 @@
 config.optimization = {
+    // todo: use https://webpack.js.org/guides/output-management/ instead of manually adding js files into html
 	splitChunks: {
 		cacheGroups: {
 			commons: {

--- a/save-frontend/webpack.config.d/plugins.js
+++ b/save-frontend/webpack.config.d/plugins.js
@@ -1,0 +1,5 @@
+const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+
+//config.plugins.push(
+//    new BundleAnalyzerPlugin()
+//);


### PR DESCRIPTION
### What's done:
* Added dependecnies
* Added react components
* Use postcss to compile bootstrap scss
* Removed task for copying webfonts during build, because they are no more used
* Added separate chunks for own code and for vendors bundle

The first change reduces bundle size from 3.17 MB to 2.44 MB, using postcss reduces it further to 2.35 MB.
It is further split into two assets:
```
Assets: 
  save-frontend.js (1.1 MiB)
  save-frontend-vendors.js (1.26 MiB)
```

Also, First Paint time is reduced from >10 sec to ~5 sec!

Further improvements can be achieved if we migrate from bootsrap+jquery to react-bootstrap

Addresses and partially closes #141 