### PR TITLE
Add AgentState.STARTING for initial agent's heartbeat

### DIFF
--- a/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/nativeMain/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -57,7 +57,7 @@ class SaveAgent(private val config: AgentConfiguration,
     /**
      * The current [AgentState] of this agent
      */
-    val state = AtomicReference(AgentState.IDLE)
+    val state = AtomicReference(AgentState.STARTING)
     private var saveProcessJob: Job? = null
 
     /**

--- a/save-agent/src/nativeTest/kotlin/org/cqfn/save/agent/SaveAgentTest.kt
+++ b/save-agent/src/nativeTest/kotlin/org/cqfn/save/agent/SaveAgentTest.kt
@@ -80,7 +80,7 @@ class SaveAgentTest {
 
     @Test
     fun `should change state to FINISHED after SAVE CLI returns`() = runBlocking {
-        assertEquals(AgentState.IDLE, saveAgentForTest.state.value)
+        assertEquals(AgentState.STARTING, saveAgentForTest.state.value)
         runBlocking { saveAgentForTest.startSaveProcess("") }
         assertEquals(AgentState.FINISHED, saveAgentForTest.state.value)
     }

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/AgentState.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/agent/AgentState.kt
@@ -36,5 +36,10 @@ enum class AgentState {
      * Agent is doing nothing
      */
     IDLE,
+
+    /**
+     * Agent has just started and hasn't received any heartbeats yet
+     */
+    STARTING,
     ;
 }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -53,6 +53,9 @@ class HeartbeatController(private val agentService: AgentService,
         )
             .then(
                 when (heartbeat.state) {
+                    // if agent sends the first heartbeat, we try to assign work for it
+                    AgentState.STARTING -> agentService.getNewTestsIds(heartbeat.agentId)
+                    // if agent idles, we try to assign work, but also check if it should be terminated
                     AgentState.IDLE -> agentService.getNewTestsIds(heartbeat.agentId)
                         .doOnSuccess {
                             if (it is WaitResponse) {

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/heartbeat/HeartbeatControllerTest.kt
@@ -169,6 +169,28 @@ class HeartbeatControllerTest {
         }
     }
 
+    @Test
+    fun `should not shutdown any agents when they are STARTING`() {
+        testHeartbeat(
+            agentStatusDtos = listOf(
+                AgentStatusDto(LocalDateTime.now(), AgentState.STARTING, "test-1"),
+                AgentStatusDto(LocalDateTime.now(), AgentState.STARTING, "test-2"),
+            ),
+            heartbeat = Heartbeat("test-1", AgentState.STARTING, ExecutionProgress(0)),
+            testBatch = TestBatch(
+                listOf(
+                    TestDto("/path/to/test-1", 1, null),
+                    TestDto("/path/to/test-2", 1, null),
+                    TestDto("/path/to/test-3", 1, null),
+                ),
+                mapOf(1L to "")
+            ),
+            mockAgentStatuses = false,
+        ) {
+            verify(dockerService, times(0)).stopAgents(any())
+        }
+    }
+
     /**
      * Test logic triggered by a heartbeat.
      *


### PR DESCRIPTION
### What's done:
* Added state STARTING
* Added tests

Previousely we had the following case:
- Agents are started
- The first agent sends IDLE, gets a batch of tests
- The second agent sends IDLE, there are no more tests
- Shutdown sequence is initiated; because all agents have IDLE in DB they all are subjects for termination
- First agent is stopped whether it has finished execution or not

This PR proposes a new state for the very first heartbeat, and for this state orchestrator doesn't check shutdown conditions.

This is part of #156 