### PR TITLE
Rerun executions with GIT type

### DIFF
--- a/db/changelog/v-1/11-changeset-test-agent-insert-data.xml
+++ b/db/changelog/v-1/11-changeset-test-agent-insert-data.xml
@@ -27,7 +27,7 @@
             <column name="start_time" value="2021-01-01 00:00:00" />
             <column name="end_time" value="2021-02-01 00:00:00" />
             <column name="status" value="RUNNING" />
-            <column name="test_suite_ids" value="4" />
+            <column name="test_suite_ids" value="ALL" />
             <column name="resources_root_path" value="resources_root_path" />
             <column name="page" value="0" />
             <column name="batch_size" value="20" />

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/SaveApplication.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/SaveApplication.kt
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.reactive.config.EnableWebFlux
 
 typealias StringResponse = ResponseEntity<String>
+typealias EmptyResponse = ResponseEntity<Void>
 
 /**
  * An entrypoint for spring for save-backend

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
@@ -99,13 +99,15 @@ class AgentsController(private val agentStatusRepository: AgentStatusRepository,
     }
 
     /**
+     * Returns containerIds for all agents for [executionId]
+     *
+     * @param executionId id of execution
+     * @return list of container ids
      */
     @GetMapping("/getAgentsIdsForExecution")
     @Transactional
-    fun findAgentIdsForExecution(@RequestParam executionId: Long): List<String> {
-        return agentRepository.findByExecutionId(executionId)
-            .map { agent -> agent.containerId }
-    }
+    fun findAgentIdsForExecution(@RequestParam executionId: Long) = agentRepository.findByExecutionId(executionId)
+        .map { agent -> agent.containerId }
 
     /**
      * Get agent by containerId.

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
@@ -99,6 +99,15 @@ class AgentsController(private val agentStatusRepository: AgentStatusRepository,
     }
 
     /**
+     */
+    @GetMapping("/getAgentsIdsForExecution")
+    @Transactional
+    fun findAgentIdsForExecution(@RequestParam executionId: Long): List<String> {
+        return agentRepository.findByExecutionId(executionId)
+            .map { agent -> agent.containerId }
+    }
+
+    /**
      * Get agent by containerId.
      *
      * @param containerId containerId of an agent.

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/AgentsController.kt
@@ -105,9 +105,8 @@ class AgentsController(private val agentStatusRepository: AgentStatusRepository,
      * @return list of container ids
      */
     @GetMapping("/getAgentsIdsForExecution")
-    @Transactional
     fun findAgentIdsForExecution(@RequestParam executionId: Long) = agentRepository.findByExecutionId(executionId)
-        .map { agent -> agent.containerId }
+        .map(Agent::containerId)
 
     /**
      * Get agent by containerId.

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -59,8 +59,9 @@ class ExecutionController(private val executionService: ExecutionService,
      */
     @GetMapping("/execution")
     @Transactional(readOnly = true)
-    fun getExecution(@RequestParam id: Long) = executionService.getExecution(id).also {
+    fun getExecution(@RequestParam id: Long) = executionService.getExecution(id).let {
         println(it.project.name)
+        ResponseEntity.status(HttpStatus.OK).body(it)
     }
 
     /**

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -58,8 +58,10 @@ class ExecutionController(private val executionService: ExecutionService,
      * @return execution if it has been found
      */
     @GetMapping("/execution")
-    @Transactional
-    fun getExecution(@RequestParam id: Long) = executionService.getExecution(id)
+    @Transactional(readOnly = true)
+    fun getExecution(@RequestParam id: Long) = executionService.getExecution(id).also {
+        println(it.project.name)
+    }
 
     /**
      * @param executionInitializationDto

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -1,7 +1,5 @@
 package org.cqfn.save.backend.controllers
 
-import org.cqfn.save.backend.EmptyResponse
-import org.cqfn.save.backend.StringResponse
 import org.cqfn.save.backend.configs.ConfigProperties
 import org.cqfn.save.backend.service.ExecutionService
 import org.cqfn.save.backend.service.GitService
@@ -63,7 +61,7 @@ class ExecutionController(private val executionService: ExecutionService,
      */
     @GetMapping("/execution")
     @Transactional(readOnly = true)
-    fun getExecution(@RequestParam id: Long): Execution = executionService.getExecution(id).orElseThrow {
+    fun getExecution(@RequestParam id: Long): Execution = executionService.findExecution(id).orElseThrow {
         ResponseStatusException(HttpStatus.NOT_FOUND, "Execution with id=$id is not found")
     }
 
@@ -125,7 +123,7 @@ class ExecutionController(private val executionService: ExecutionService,
     @Transactional
     @Suppress("UnsafeCallOnNullableType")
     fun rerunExecution(@RequestParam id: Long): Mono<String> {
-        val execution = executionService.getExecution(id).orElseThrow {
+        val execution = executionService.findExecution(id).orElseThrow {
             IllegalArgumentException("Can't rerun execution $id, because it does not exist")
         }
         val git = requireNotNull(gitService.getRepositoryDtoByProject(execution.project)) {
@@ -133,7 +131,7 @@ class ExecutionController(private val executionService: ExecutionService,
         }
         val propertiesRelativePath = execution.testSuiteIds?.let {
             require(it == "ALL") { "Only executions with all tests suites from a GIT project are supported now" }
-            testSuitesService.getTestSuitesByProject(execution.project)
+            testSuitesService.findTestSuitesByProject(execution.project)
         }!!
             .map {
                 it.propertiesRelativePath

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -130,7 +130,7 @@ class ExecutionController(private val executionService: ExecutionService,
             "Can't rerun execution $id, project ${execution.project.name} has no associated git address"
         }
         val propertiesRelativePath = execution.testSuiteIds?.let {
-            require(it == "ALL") { "Only executions with all tests suites from a GIT project are supported now" }
+            require(it == "ALL") { "Only executions with \"ALL\" tests suites from a GIT project are supported now" }
             testSuitesService.findTestSuitesByProject(execution.project)
         }!!
             .map {

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -1,18 +1,24 @@
 package org.cqfn.save.backend.controllers
 
+import org.cqfn.save.backend.configs.ConfigProperties
 import org.cqfn.save.backend.service.ExecutionService
+import org.cqfn.save.domain.toSdk
 import org.cqfn.save.entities.Execution
+import org.cqfn.save.entities.ExecutionRequest
+import org.cqfn.save.entities.GitDto
 import org.cqfn.save.execution.ExecutionDto
 import org.cqfn.save.execution.ExecutionInitializationDto
 import org.cqfn.save.execution.ExecutionUpdateDto
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
 
@@ -22,7 +28,11 @@ typealias ExecutionDtoListResponse = ResponseEntity<List<ExecutionDto>>
  * Controller that accepts executions
  */
 @RestController
-class ExecutionController(private val executionService: ExecutionService) {
+class ExecutionController(private val executionService: ExecutionService,
+                          config: ConfigProperties,
+) {
+    private val preprocessorWebClient = WebClient.create(config.preprocessorUrl)
+
     /**
      * @param execution
      * @return id of created [Execution]
@@ -37,6 +47,15 @@ class ExecutionController(private val executionService: ExecutionService) {
     fun updateExecution(@RequestBody executionUpdateDto: ExecutionUpdateDto) {
         executionService.updateExecution(executionUpdateDto)
     }
+
+    /**
+     * Get execution by id
+     *
+     * @param id id of execution
+     * @return execution if it has been found
+     */
+    @GetMapping("/execution")
+    fun getExecution(@RequestParam id: Long) = executionService.getExecution(id)
 
     /**
      * @param executionInitializationDto
@@ -85,4 +104,29 @@ class ExecutionController(private val executionService: ExecutionService) {
                         ResponseStatusException(HttpStatus.NOT_FOUND, "Execution not found for project (name=$name, owner=$owner)")
                     }
                 }
+
+    /**
+     * Accepts a request to rerun an existing execution
+     *
+     * @param id id of an existing execution
+     * @return bodiless response
+     */
+    @PostMapping("/rerunExecution")
+    @Transactional
+    fun rerunExecution(@RequestParam id: Long): Mono<ResponseEntity<Void>> {
+        val execution = requireNotNull(executionService.getExecution(id)) {
+            "Can't rerun execution $id, because it does not exist"
+        }
+        val executionRequest = ExecutionRequest(
+            project = execution.project,
+            gitDto = GitDto(execution.project.url!!, hash = execution.version),
+            sdk = execution.sdk.toSdk(),
+            executionId = execution.id
+        )
+        return preprocessorWebClient.post()
+            .uri("/rerunExecution")
+            .bodyValue(executionRequest)
+            .retrieve()
+            .toBodilessEntity()
+    }
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.backend.controllers
 
 import org.cqfn.save.backend.EmptyResponse
+import org.cqfn.save.backend.StringResponse
 import org.cqfn.save.backend.configs.ConfigProperties
 import org.cqfn.save.backend.service.ExecutionService
 import org.cqfn.save.backend.service.GitService
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Mono
 
@@ -122,7 +124,7 @@ class ExecutionController(private val executionService: ExecutionService,
     @PostMapping("/rerunExecution")
     @Transactional
     @Suppress("UnsafeCallOnNullableType")
-    fun rerunExecution(@RequestParam id: Long): Mono<EmptyResponse> {
+    fun rerunExecution(@RequestParam id: Long): Mono<String> {
         val execution = executionService.getExecution(id).orElseThrow {
             IllegalArgumentException("Can't rerun execution $id, because it does not exist")
         }
@@ -149,6 +151,6 @@ class ExecutionController(private val executionService: ExecutionService,
             .uri("/rerunExecution")
             .bodyValue(executionRequest)
             .retrieve()
-            .toBodilessEntity()
+            .bodyToMono()
     }
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -58,6 +58,7 @@ class ExecutionController(private val executionService: ExecutionService,
      * @return execution if it has been found
      */
     @GetMapping("/execution")
+    @Transactional
     fun getExecution(@RequestParam id: Long) = executionService.getExecution(id)
 
     /**

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -114,6 +114,7 @@ class ExecutionController(private val executionService: ExecutionService,
      */
     @PostMapping("/rerunExecution")
     @Transactional
+    @Suppress("UnsafeCallOnNullableType")
     fun rerunExecution(@RequestParam id: Long): Mono<EmptyResponse> {
         val execution = requireNotNull(executionService.getExecution(id)) {
             "Can't rerun execution $id, because it does not exist"

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -59,10 +59,7 @@ class ExecutionController(private val executionService: ExecutionService,
      */
     @GetMapping("/execution")
     @Transactional(readOnly = true)
-    fun getExecution(@RequestParam id: Long) = executionService.getExecution(id).let {
-        println(it.project.name)
-        ResponseEntity.status(HttpStatus.OK).body(it)
-    }
+    fun getExecution(@RequestParam id: Long): Execution = executionService.getExecution(id).orElseThrow()
 
     /**
      * @param executionInitializationDto

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/ExecutionController.kt
@@ -1,5 +1,6 @@
 package org.cqfn.save.backend.controllers
 
+import org.cqfn.save.backend.EmptyResponse
 import org.cqfn.save.backend.configs.ConfigProperties
 import org.cqfn.save.backend.service.ExecutionService
 import org.cqfn.save.domain.toSdk
@@ -113,7 +114,7 @@ class ExecutionController(private val executionService: ExecutionService,
      */
     @PostMapping("/rerunExecution")
     @Transactional
-    fun rerunExecution(@RequestParam id: Long): Mono<ResponseEntity<Void>> {
+    fun rerunExecution(@RequestParam id: Long): Mono<EmptyResponse> {
         val execution = requireNotNull(executionService.getExecution(id)) {
             "Can't rerun execution $id, because it does not exist"
         }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/AgentStatusRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/AgentStatusRepository.kt
@@ -36,5 +36,11 @@ interface AgentRepository : BaseEntityRepository<Agent>, JpaSpecificationExecuto
      */
     fun findByContainerId(agentId: String): Agent?
 
+    /**
+     * Find all agents with [executionId]
+     *
+     * @param executionId id of execution
+     * @return list of agents
+     */
     fun findByExecutionId(executionId: Long): List<Agent>
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/AgentStatusRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/AgentStatusRepository.kt
@@ -35,4 +35,6 @@ interface AgentRepository : BaseEntityRepository<Agent>, JpaSpecificationExecuto
      * @return [Agent]
      */
     fun findByContainerId(agentId: String): Agent?
+
+    fun findByExecutionId(executionId: Long): List<Agent>
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/TestSuiteRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/TestSuiteRepository.kt
@@ -16,5 +16,9 @@ interface TestSuiteRepository : BaseEntityRepository<TestSuite>, QueryByExampleE
      */
     fun findAllByTypeIs(testSuiteType: TestSuiteType): List<TestSuite>
 
+    /**
+     * @param projectId id of the project associated with test suites
+     * @return a list of test suites
+     */
     fun findByProjectId(projectId: Long): List<TestSuite>
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/TestSuiteRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/TestSuiteRepository.kt
@@ -15,4 +15,6 @@ interface TestSuiteRepository : BaseEntityRepository<TestSuite>, QueryByExampleE
      * @return list of test suites by type
      */
     fun findAllByTypeIs(testSuiteType: TestSuiteType): List<TestSuite>
+
+    fun findByProjectId(projectId: Long): List<TestSuite>
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/ExecutionService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/ExecutionService.kt
@@ -28,12 +28,12 @@ class ExecutionService(private val executionRepository: ExecutionRepository) {
     private lateinit var projectRepository: ProjectRepository
 
     /**
-     * Get execution by id
+     * Find execution by id
      *
      * @param id id of execution
      * @return execution if it has been found
      */
-    fun getExecution(id: Long) = executionRepository.findById(id)
+    fun findExecution(id: Long) = executionRepository.findById(id)
 
     /**
      * @param execution

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/ExecutionService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/ExecutionService.kt
@@ -33,7 +33,7 @@ class ExecutionService(private val executionRepository: ExecutionRepository) {
      * @param id id of execution
      * @return execution if it has been found
      */
-    fun getExecution(id: Long) = executionRepository.getById(id)
+    fun getExecution(id: Long) = executionRepository.findById(id)
 
     /**
      * @param execution

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
@@ -52,6 +52,10 @@ class TestSuitesService {
     fun getStandardTestSuites() =
             testSuiteRepository.findAllByTypeIs(TestSuiteType.STANDARD).map { it.toDto() }
 
-    fun getTestSuitesByProject(project: Project) =
-        testSuiteRepository.findByProjectId(project.id!!)
+    /**
+     * @param project a project associated with test suites
+     * @return a list of test suites
+     */
+    fun findTestSuitesByProject(project: Project) =
+            testSuiteRepository.findByProjectId(project.id!!)
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
@@ -57,5 +57,7 @@ class TestSuitesService {
      * @return a list of test suites
      */
     fun findTestSuitesByProject(project: Project) =
-            testSuiteRepository.findByProjectId(project.id!!)
+            testSuiteRepository.findByProjectId(
+                requireNotNull(project.id) { "Cannot find test suites for project with missing id (name=${project.name}, owner=${project.owner})" }
+            )
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.backend.service
 
 import org.cqfn.save.backend.repository.TestSuiteRepository
+import org.cqfn.save.entities.Project
 import org.cqfn.save.entities.TestSuite
 import org.cqfn.save.testsuite.TestSuiteDto
 import org.cqfn.save.testsuite.TestSuiteType
@@ -50,4 +51,7 @@ class TestSuitesService {
      */
     fun getStandardTestSuites() =
             testSuiteRepository.findAllByTypeIs(TestSuiteType.STANDARD).map { it.toDto() }
+
+    fun getTestSuitesByProject(project: Project) =
+        testSuiteRepository.findByProjectId(project.id!!)
 }

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/ExecutionControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/ExecutionControllerTest.kt
@@ -245,7 +245,10 @@ class ExecutionControllerTest {
     @Test
     fun `should send request to preprocessor to rerun execution`() {
         mockServerPreprocessor.enqueue(
-            MockResponse().setResponseCode(200)
+            MockResponse().setResponseCode(202)
+                .setHeader("Accept", "application/json")
+                .setHeader("Content-Type", "application/json")
+                .setBody("Clone pending")
         )
         val assertions = CompletableFuture.supplyAsync {
             listOf(
@@ -254,7 +257,7 @@ class ExecutionControllerTest {
         }
 
         webClient.post()
-            .uri("/rerunExecution?id=1")
+            .uri("/rerunExecution?id=2")
             .exchange()
             .expectStatus()
             .isOk

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/ExecutionControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/ExecutionControllerTest.kt
@@ -1,7 +1,5 @@
 package org.cqfn.save.backend.controller
 
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import org.cqfn.save.backend.SaveApplication
 import org.cqfn.save.backend.repository.ExecutionRepository
 import org.cqfn.save.backend.repository.ProjectRepository
@@ -13,8 +11,10 @@ import org.cqfn.save.execution.ExecutionInitializationDto
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionType
 import org.cqfn.save.execution.ExecutionUpdateDto
-import org.junit.jupiter.api.AfterAll
 
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/execution/ExecutionDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/execution/ExecutionDto.kt
@@ -23,4 +23,5 @@ class ExecutionDto(
     val passedTests: Long,
     val failedTests: Long,
     val skippedTests: Long,
+    val resourcesRootPath: String,
 )

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/execution/ExecutionDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/execution/ExecutionDto.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @Suppress("LongParameterList")
-class ExecutionDto(
+data class ExecutionDto(
     val id: Long,
     val status: ExecutionStatus,
     val type: ExecutionType,

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/execution/ExecutionDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/execution/ExecutionDto.kt
@@ -23,5 +23,4 @@ data class ExecutionDto(
     val passedTests: Long,
     val failedTests: Long,
     val skippedTests: Long,
-    val resourcesRootPath: String,
 )

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/Execution.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/Execution.kt
@@ -77,6 +77,6 @@ class Execution(
         passedTests,
         failedTests,
         skippedTests,
-        resourcesRootPath!!
+        resourcesRootPath ?: "N/A"
     )
 }

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/Execution.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/Execution.kt
@@ -77,6 +77,5 @@ class Execution(
         passedTests,
         failedTests,
         skippedTests,
-        resourcesRootPath ?: "N/A"
     )
 }

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/Execution.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/Execution.kt
@@ -76,6 +76,7 @@ class Execution(
         endTime?.toEpochSecond(ZoneOffset.UTC),
         passedTests,
         failedTests,
-        skippedTests
+        skippedTests,
+        resourcesRootPath!!
     )
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -83,7 +83,7 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
                     attrs.onClickFunction = {
                         attrs.disabled = true
                         GlobalScope.launch {
-                            post("${window.location.origin}/rerunExecution?id=${props.executionId}", Headers(), null)
+                            post("${window.location.origin}/rerunExecution?id=${props.executionId}", Headers(), undefined)
                         }.invokeOnCompletion {
                             window.alert("Rerun request successfully submitted")
                         }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -75,10 +75,12 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
     @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR", "TOO_LONG_FUNCTION", "LongMethod")
     override fun RBuilder.render() {
         div {
-            +("Project version: ${(state.executionDto?.version ?: "N/A")}")
-            div(classes = "float-right") {
+            div("flex-auto") {
+                +("Project version: ${(state.executionDto?.version ?: "N/A")}")
+            }
+            div {
                 +"${state.executionDto?.status ?: "Status N/A"}"
-                button {
+                button(classes = "btn btn-primary") {
                     +"Rerun execution"
                     attrs.onClickFunction = {
                         attrs.disabled = true

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -27,8 +27,12 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.await
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
+import kotlinx.html.js.onClickFunction
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import org.cqfn.save.execution.ExecutionStatus
+import org.cqfn.save.frontend.utils.post
+import react.dom.button
 
 /**
  * [RProps] for execution results view
@@ -73,6 +77,20 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
     override fun RBuilder.render() {
         div {
             +("Project version: ${(state.executionDto?.version ?: "N/A")}")
+            div(classes = "float-right") {
+                +"${state.executionDto?.status ?: "Status N/A"}"
+                button {
+                    +"Rerun execution"
+                    attrs.onClickFunction = {
+                        attrs.disabled = true
+                        GlobalScope.launch {
+                            post("${window.location.origin}/rerunExecution?id=${props.executionId}", Headers(), null)
+                        }.invokeOnCompletion {
+                            window.alert("Rerun request successfully submitted")
+                        }
+                    }
+                }
+            }
         }
         // fixme: table is rendered twice because of state change when `executionDto` is fetched
         child(tableComponent(

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -9,6 +9,7 @@ import org.cqfn.save.execution.ExecutionDto
 import org.cqfn.save.frontend.components.tables.tableComponent
 import org.cqfn.save.frontend.utils.decodeFromJsonString
 import org.cqfn.save.frontend.utils.get
+import org.cqfn.save.frontend.utils.post
 import org.cqfn.save.frontend.utils.unsafeMap
 
 import org.w3c.fetch.Headers
@@ -17,6 +18,7 @@ import react.RComponent
 import react.RProps
 import react.RState
 import react.child
+import react.dom.button
 import react.dom.div
 import react.dom.td
 import react.setState
@@ -30,9 +32,6 @@ import kotlinx.datetime.Instant
 import kotlinx.html.js.onClickFunction
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import org.cqfn.save.execution.ExecutionStatus
-import org.cqfn.save.frontend.utils.post
-import react.dom.button
 
 /**
  * [RProps] for execution results view

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -75,11 +75,13 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
     @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR", "TOO_LONG_FUNCTION", "LongMethod")
     override fun RBuilder.render() {
         div {
-            div("flex-auto") {
+            div("p-2 flex-auto") {
                 +("Project version: ${(state.executionDto?.version ?: "N/A")}")
             }
-            div {
-                +"${state.executionDto?.status ?: "Status N/A"}"
+            div("d-flex") {
+                div("p-2 mr-auto") {
+                    +"Status: ${state.executionDto?.status ?: "N/A"}"
+                }
                 button(classes = "btn btn-primary") {
                     +"Rerun execution"
                     attrs.onClickFunction = {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -67,7 +67,7 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
         GlobalScope.launch {
             val headers = Headers().also { it.set("Accept", "application/json") }
             val executionDtoFromBackend: ExecutionDto = get("${window.location.origin}/executionDto?executionId=${props.executionId}", headers)
-                .decodeFromJsonString<ExecutionDto>()
+                .decodeFromJsonString()
             setState { executionDto = executionDtoFromBackend }
         }
     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ExecutionView.kt
@@ -72,7 +72,7 @@ class ExecutionView : RComponent<ExecutionProps, ExecutionState>() {
         }
     }
 
-    @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR", "TOO_LONG_FUNCTION")
+    @Suppress("EMPTY_BLOCK_STRUCTURE_ERROR", "TOO_LONG_FUNCTION", "LongMethod")
     override fun RBuilder.render() {
         div {
             +("Project version: ${(state.executionDto?.version ?: "N/A")}")

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/SaveOrchestrator.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/SaveOrchestrator.kt
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.reactive.config.EnableWebFlux
 
 internal typealias BodilessResponseEntity = ResponseEntity<Void>
+internal typealias TextResponse = ResponseEntity<String>
 
 /**
  * An entrypoint for spring boot for save-orchestrator

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/AgentsController.kt
@@ -105,14 +105,14 @@ class AgentsController {
      * @return empty response
      */
     @PostMapping("/cleanup")
-    fun stopAgents(@RequestParam executionId: Long) = Mono.just(ResponseEntity<Void>(HttpStatus.ACCEPTED)).doOnSuccess {
+    fun cleanup(@RequestParam executionId: Long) = Mono.just(ResponseEntity<Void>(HttpStatus.ACCEPTED)).doOnSuccess {
         agentService.getAgentsForExecution(executionId)
             .flatMapMany(::fromIterable)
             .map { id ->
-                dockerService.containerManager.dockerClient.removeContainerCmd(id)
+                dockerService.removeContainer(id)
             }
             .doOnComplete {
-                dockerService.containerManager.dockerClient.removeImageCmd(imageName(executionId))
+                dockerService.removeImage(imageName(executionId))
             }
             .subscribeOn(Schedulers.boundedElastic())
             .subscribe()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/AgentsController.kt
@@ -106,18 +106,18 @@ class AgentsController {
      */
     @PostMapping("/cleanup")
     fun cleanup(@RequestParam executionId: Long) =
-        agentService.getAgentsForExecution(executionId)
-            .flatMapMany(::fromIterable)
-            .map { id ->
-                dockerService.removeContainer(id)
-            }
-            .doOnComplete {
-                dockerService.removeImage(imageName(executionId))
-            }
-            .collectList()
-            .flatMap {
-                Mono.just(ResponseEntity<Void>(HttpStatus.OK))
-            }
+            agentService.getAgentIdsForExecution(executionId)
+                .flatMapMany(::fromIterable)
+                .map { id ->
+                    dockerService.removeContainer(id)
+                }
+                .doOnComplete {
+                    dockerService.removeImage(imageName(executionId))
+                }
+                .collectList()
+                .flatMap {
+                    Mono.just(ResponseEntity<Void>(HttpStatus.OK))
+                }
 
     companion object {
         private val log = LoggerFactory.getLogger(AgentsController::class.java)

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/AgentsController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/AgentsController.kt
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Flux.fromIterable
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
@@ -101,6 +100,9 @@ class AgentsController {
 
     /**
      * Delete containers and images associated with execution [executionId]
+     *
+     * @param executionId id of execution
+     * @return empty response
      */
     @PostMapping("/cleanup")
     fun stopAgents(@RequestParam executionId: Long) = Mono.just(ResponseEntity<Void>(HttpStatus.ACCEPTED)).doOnSuccess {
@@ -115,7 +117,6 @@ class AgentsController {
             .subscribeOn(Schedulers.boundedElastic())
             .subscribe()
     }
-
 
     companion object {
         private val log = LoggerFactory.getLogger(AgentsController::class.java)

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -149,7 +149,7 @@ class AgentService(configProperties: ConfigProperties) {
      * @return agent
      */
     @Suppress("TYPE_ALIAS")
-    fun getAgentsForExecution(executionId: Long): Mono<List<String>> = webClientBackend
+    fun getAgentIdsForExecution(executionId: Long): Mono<List<String>> = webClientBackend
         .get()
         .uri("/getAgentsIdsForExecution?executionId=$executionId")
         .retrieve()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -143,6 +143,17 @@ class AgentService(configProperties: ConfigProperties) {
                 )
 
     /**
+     */
+    @Suppress("TYPE_ALIAS")
+    fun getAgentsForExecution(executionId: Long): Mono<List<String>> {
+        return webClientBackend
+            .get()
+            .uri("/getAgentsIdsForExecution?executionId=$executionId")
+            .retrieve()
+            .bodyToMono()
+    }
+
+    /**
      * Get list of agent ids (containerIds) for agents that have completed their jobs.
      *
      * @param agentId containerId of an agent

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -11,7 +11,6 @@ import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
 import org.cqfn.save.orchestrator.BodilessResponseEntity
-import org.cqfn.save.orchestrator.TextResponse
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.test.TestBatch
 

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -150,7 +150,7 @@ class AgentService(configProperties: ConfigProperties) {
      * @return agent
      */
     @Suppress("TYPE_ALIAS")
-    fun getAgentsForExecution(executionId: Long): Mono<TextResponse> = webClientBackend
+    fun getAgentsForExecution(executionId: Long): Mono<List<String>> = webClientBackend
         .get()
         .uri("/getAgentsIdsForExecution?executionId=$executionId")
         .retrieve()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -11,6 +11,7 @@ import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
 import org.cqfn.save.orchestrator.BodilessResponseEntity
+import org.cqfn.save.orchestrator.TextResponse
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.test.TestBatch
 
@@ -143,15 +144,17 @@ class AgentService(configProperties: ConfigProperties) {
                 )
 
     /**
+     * Returns agent for execution with id [executionId]
+     *
+     * @param executionId id of execution
+     * @return agent
      */
     @Suppress("TYPE_ALIAS")
-    fun getAgentsForExecution(executionId: Long): Mono<List<String>> {
-        return webClientBackend
-            .get()
-            .uri("/getAgentsIdsForExecution?executionId=$executionId")
-            .retrieve()
-            .bodyToMono()
-    }
+    fun getAgentsForExecution(executionId: Long): Mono<TextResponse> = webClientBackend
+        .get()
+        .uri("/getAgentsIdsForExecution?executionId=$executionId")
+        .retrieve()
+        .bodyToMono()
 
     /**
      * Get list of agent ids (containerIds) for agents that have completed their jobs.

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -103,6 +103,10 @@ class DockerService(private val configProperties: ConfigProperties) {
                 false
             }
 
+    fun removeImage(imageName: String) = containerManager.dockerClient.removeImageCmd(imageName)
+
+    fun removeContainer(containerId: String) = containerManager.dockerClient.removeContainerCmd(containerId)
+
     @Suppress("TOO_LONG_FUNCTION")
     private fun buildBaseImageForExecution(execution: Execution): Pair<String, String> {
         val resourcesPath = File(

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -182,5 +182,12 @@ class DockerService(private val configProperties: ConfigProperties) {
     }
 }
 
+/**
+ * @param executionId
+ */
 internal fun imageName(executionId: Long) = "save-execution:$executionId"
+
+/**
+ * @param id
+ */
 internal fun containerName(id: Int) = "save-execution-$id"

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -109,18 +109,18 @@ class DockerService(private val configProperties: ConfigProperties) {
      * @param imageName name of the image to remove
      * @return an instance of docker command
      */
-    fun removeImage(imageName: String): RemoveImageCmd {
+    fun removeImage(imageName: String) {
         log.info("Removing image $imageName")
-        return containerManager.dockerClient.removeImageCmd(imageName)
+        containerManager.dockerClient.removeImageCmd(imageName).exec()
     }
 
     /**
      * @param containerId id of container to remove
      * @return an instance of docker command
      */
-    fun removeContainer(containerId: String): RemoveContainerCmd {
+    fun removeContainer(containerId: String) {
         log.info("Removing container $containerId")
-        return containerManager.dockerClient.removeContainerCmd(containerId)
+        containerManager.dockerClient.removeContainerCmd(containerId).exec()
     }
 
     @Suppress("TOO_LONG_FUNCTION", "UnsafeCallOnNullableType")

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -190,4 +190,4 @@ internal fun imageName(executionId: Long) = "save-execution:$executionId"
 /**
  * @param id
  */
-internal fun containerName(id: Int) = "save-execution-$id"
+internal fun containerName(id: String) = "save-execution-$id"

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -6,8 +6,6 @@ import org.cqfn.save.execution.ExecutionUpdateDto
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.orchestrator.docker.ContainerManager
 
-import com.github.dockerjava.api.command.RemoveContainerCmd
-import com.github.dockerjava.api.command.RemoveImageCmd
 import com.github.dockerjava.api.exception.DockerException
 import generated.SAVE_CORE_VERSION
 import org.apache.commons.io.FileUtils

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -109,13 +109,19 @@ class DockerService(private val configProperties: ConfigProperties) {
      * @param imageName name of the image to remove
      * @return an instance of docker command
      */
-    fun removeImage(imageName: String): RemoveImageCmd = containerManager.dockerClient.removeImageCmd(imageName)
+    fun removeImage(imageName: String): RemoveImageCmd {
+        log.info("Removing image $imageName")
+        return containerManager.dockerClient.removeImageCmd(imageName)
+    }
 
     /**
      * @param containerId id of container to remove
      * @return an instance of docker command
      */
-    fun removeContainer(containerId: String): RemoveContainerCmd = containerManager.dockerClient.removeContainerCmd(containerId)
+    fun removeContainer(containerId: String): RemoveContainerCmd {
+        log.info("Removing container $containerId")
+        return containerManager.dockerClient.removeContainerCmd(containerId)
+    }
 
     @Suppress("TOO_LONG_FUNCTION", "UnsafeCallOnNullableType")
     private fun buildBaseImageForExecution(execution: Execution): Pair<String, String> {

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -123,7 +123,7 @@ class DockerService(private val configProperties: ConfigProperties) {
         val baseImage = execution.sdk
         val imageId = containerManager.buildImageWithResources(
             baseImage = baseImage,
-            imageName = "save-execution:${execution.id}",
+            imageName = imageName(execution.id!!),
             baseDir = resourcesPath,
             resourcesPath = executionDir,
             runCmd = """RUN apt-get update && env DEBIAN_FRONTEND="noninteractive" apt-get install -y libcurl4-openssl-dev tzdata && rm -rf /var/lib/apt/lists/*
@@ -145,7 +145,7 @@ class DockerService(private val configProperties: ConfigProperties) {
             imageId,
             executionDir,
             runCmd,
-            "save-execution-$containerNumber",
+            containerName(containerNumber),
         )
         val agentPropertiesFile = createTempDirectory("agent")
             .resolve("agent.properties")
@@ -181,3 +181,6 @@ class DockerService(private val configProperties: ConfigProperties) {
         private const val SAVE_CLI_EXECUTABLE_NAME = "save-$SAVE_CORE_VERSION-linuxX64.kexe"
     }
 }
+
+internal fun imageName(executionId: Long) = "save-execution:$executionId"
+internal fun containerName(id: Int) = "save-execution-$id"

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -1,13 +1,13 @@
 package org.cqfn.save.orchestrator.service
 
-import com.github.dockerjava.api.command.RemoveContainerCmd
-import com.github.dockerjava.api.command.RemoveImageCmd
 import org.cqfn.save.entities.Execution
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
 import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.orchestrator.docker.ContainerManager
 
+import com.github.dockerjava.api.command.RemoveContainerCmd
+import com.github.dockerjava.api.command.RemoveImageCmd
 import com.github.dockerjava.api.exception.DockerException
 import generated.SAVE_CORE_VERSION
 import org.apache.commons.io.FileUtils
@@ -117,7 +117,7 @@ class DockerService(private val configProperties: ConfigProperties) {
      */
     fun removeContainer(containerId: String): RemoveContainerCmd = containerManager.dockerClient.removeContainerCmd(containerId)
 
-    @Suppress("TOO_LONG_FUNCTION")
+    @Suppress("TOO_LONG_FUNCTION", "UnsafeCallOnNullableType")
     private fun buildBaseImageForExecution(execution: Execution): Pair<String, String> {
         val resourcesPath = File(
             configProperties.testResources.basePath,

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -1,5 +1,7 @@
 package org.cqfn.save.orchestrator.service
 
+import com.github.dockerjava.api.command.RemoveContainerCmd
+import com.github.dockerjava.api.command.RemoveImageCmd
 import org.cqfn.save.entities.Execution
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
@@ -103,9 +105,17 @@ class DockerService(private val configProperties: ConfigProperties) {
                 false
             }
 
-    fun removeImage(imageName: String) = containerManager.dockerClient.removeImageCmd(imageName)
+    /**
+     * @param imageName name of the image to remove
+     * @return an instance of docker command
+     */
+    fun removeImage(imageName: String): RemoveImageCmd = containerManager.dockerClient.removeImageCmd(imageName)
 
-    fun removeContainer(containerId: String) = containerManager.dockerClient.removeContainerCmd(containerId)
+    /**
+     * @param containerId id of container to remove
+     * @return an instance of docker command
+     */
+    fun removeContainer(containerId: String): RemoveContainerCmd = containerManager.dockerClient.removeContainerCmd(containerId)
 
     @Suppress("TOO_LONG_FUNCTION")
     private fun buildBaseImageForExecution(execution: Execution): Pair<String, String> {

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/agents/AgentsControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/agents/AgentsControllerTest.kt
@@ -1,7 +1,5 @@
 package org.cqfn.save.orchestrator.controller.agents
 
-import com.github.dockerjava.api.command.RemoveContainerCmd
-import com.github.dockerjava.api.command.RemoveImageCmd
 import org.cqfn.save.agent.ExecutionLogs
 import org.cqfn.save.domain.Sdk
 import org.cqfn.save.entities.Execution
@@ -22,7 +20,10 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyList
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,9 +44,6 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 
 @WebFluxTest(controllers = [AgentsController::class])
 @Import(AgentService::class, Beans::class)

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/agents/AgentsControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/agents/AgentsControllerTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever

--- a/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/agents/AgentsControllerTest.kt
+++ b/save-orchestrator/src/test/kotlin/org/cqfn/save/orchestrator/controller/agents/AgentsControllerTest.kt
@@ -176,14 +176,12 @@ class AgentsControllerTest {
                 .setHeader("Content-Type", "application/json")
                 .setBody(Json.encodeToString(listOf("container-1", "container-2", "container-3")))
         )
-        whenever(dockerService.removeContainer(any())).thenReturn(mock())
-        whenever(dockerService.removeImage(any())).thenReturn(mock())
 
         webClient.post()
             .uri("/cleanup?executionId=42")
             .exchange()
             .expectStatus()
-            .isAccepted
+            .isOk
 
         Thread.sleep(2_500)
         verify(dockerService, times(3)).removeContainer(anyString())

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -323,6 +323,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
         projectRootRelativePath: String,
         testSuiteDtos: List<TestSuiteDto>?,
     ): Mono<StatusResponse> {
+        log.info("Processing execution ${execution.toDto()}")
         val executionType = execution.type
         testSuiteDtos?.let {
             require(executionType == ExecutionType.STANDARD) { "Test suites shouldn't be provided unless ExecutionType is STANDARD (actual: $executionType)" }

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -50,8 +50,10 @@ import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.util.function.component1
 import reactor.kotlin.core.util.function.component2
+import reactor.netty.http.client.HttpClientRequest
 
 import java.io.File
+import java.time.Duration
 import java.util.stream.Collectors
 
 import kotlin.io.path.ExperimentalPathApi
@@ -151,6 +153,11 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
                 .flatMap { (execution, location) ->
                     webClientOrchestrator.post()
                         .uri("/cleanup?executionId=${execution.id}")
+                        .httpRequest {
+                            // increased timeout, because orchestrator should finish cleaning up first
+                            it.getNativeRequest<HttpClientRequest>()
+                                .responseTimeout(Duration.ofSeconds(10))
+                        }
                         .retrieve()
                         .toBodilessEntity().map {
                             Pair(execution, location)

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -133,7 +133,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
      * @return status 202
      */
     @PostMapping("/rerunExecution")
-    fun rerunExecution(@RequestBody executionRerunRequest: ExecutionRequest) = Mono.fromCallable<ResponseEntity<String>> {
+    fun rerunExecution(@RequestBody executionRerunRequest: ExecutionRequest) = Mono.fromCallable {
         requireNotNull(executionRerunRequest.executionId) { "Can't rerun execution with unknown id" }
         ResponseEntity("Clone pending", HttpStatus.ACCEPTED)
     }
@@ -367,6 +367,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
         }
     }
 
+    @Suppress("MagicNumber")
     private fun cleanupInOrchestrator(executionId: Long) =
             webClientOrchestrator.post()
                 .uri("/cleanup?executionId=$executionId")

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -158,6 +158,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
                         null
                     )
                 }
+                .log()
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe()
         }

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -124,8 +124,10 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
         }
 
     /**
-     * @param executionRerunRequest
-     * @return
+     * Accept execution rerun request
+     *
+     * @param executionRerunRequest request
+     * @return status 202
      */
     @PostMapping("/rerunExecution")
     fun rerunExecution(@RequestBody executionRerunRequest: ExecutionRequest) = Mono.fromCallable<ResponseEntity<String>> {

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -132,6 +132,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
      * @param executionRerunRequest request
      * @return status 202
      */
+    @Suppress("UnsafeCallOnNullableType")
     @PostMapping("/rerunExecution")
     fun rerunExecution(@RequestBody executionRerunRequest: ExecutionRequest) = Mono.fromCallable {
         requireNotNull(executionRerunRequest.executionId) { "Can't rerun execution with unknown id" }

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -298,6 +298,7 @@ class DownloadProjectTest(
     }
 
     @Test
+    @Suppress("LongMethod")
     fun `rerun execution`() {
         val project = Project("owner", "someName", null, "descr").apply {
             id = 42L

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -348,12 +348,12 @@ class DownloadProjectTest(
         )
         val assertions = CompletableFuture.supplyAsync {
             sequenceOf(
-                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
-                mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
-                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
-                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
-                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
-                mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(360, TimeUnit.SECONDS),
+                mockServerOrchestrator.takeRequest(360, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(360, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(360, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(360, TimeUnit.SECONDS),
+                mockServerOrchestrator.takeRequest(360, TimeUnit.SECONDS),
             ).onEach {
                 logger.info("Request $it")
             }

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -308,31 +308,42 @@ class DownloadProjectTest(
         }
         val request = ExecutionRequest(project, GitDto("https://github.com/cqfn/save"), "examples/kotlin-diktat/save.properties", Sdk.Default, execution.id)
 
-        listOf(
-            // /updateExecution
-            MockResponse().setResponseCode(200),
-            // /execution
+        // /updateExecution
+        mockServerBackend.enqueue(
             MockResponse().setResponseCode(200)
+        )
+        // /cleanup
+        mockServerOrchestrator.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        // /execution
+        mockServerBackend.enqueue(
+            MockResponse()
+                .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
-                .setBody(objectMapper.writeValueAsString(execution)),
-            // /saveTestSuites
-            MockResponse().setResponseCode(200)
+                .setBody(objectMapper.writeValueAsString(execution))
+        )
+        // /saveTestSuites
+        mockServerBackend.enqueue(
+            MockResponse()
+                .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(objectMapper.writeValueAsString(
                     listOf(
                         TestSuite(TestSuiteType.PROJECT, "", project, LocalDateTime.now(), "save.properties")
                     )
                 )),
-            // /initializeTests?executionId=$executionId
-            MockResponse().setResponseCode(200)
-        ).forEach(mockServerBackend::enqueue)
-        // /cleanup
-        mockServerOrchestrator.enqueue(
-            MockResponse().setResponseCode(200)
+        )
+        // /initializeTests?executionId=$executionId
+        mockServerBackend.enqueue(
+            MockResponse()
+                .setResponseCode(200)
         )
         // /initializeAgents
         mockServerOrchestrator.enqueue(
-            MockResponse().setResponseCode(200)
+            MockResponse()
+                .setResponseCode(200)
         )
         val assertions = CompletableFuture.supplyAsync {
             listOf(
@@ -352,6 +363,8 @@ class DownloadProjectTest(
             .exchange()
             .expectStatus()
             .isAccepted
+            .expectBody<String>()
+            .isEqualTo("Clone pending")
         Thread.sleep(2500)
 
         assertions.orTimeout(60, TimeUnit.SECONDS).join().forEach { Assertions.assertNotNull(it) }

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.QueueDispatcher
-import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
@@ -58,6 +56,7 @@ import kotlin.io.path.ExperimentalPathApi
 @WebFluxTest(controllers = [DownloadProjectController::class])
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureWebTestClient(timeout = "60000")
+@Suppress("TOO_LONG_FUNCTION")
 class DownloadProjectTest(
     @Autowired private val webClient: WebTestClient,
     @Autowired private val configProperties: ConfigProperties,
@@ -107,7 +106,6 @@ class DownloadProjectTest(
     /**
      * This one covers logic of connecting to services
      */
-    @Suppress("TOO_LONG_FUNCTION")
     @Test
     fun testCorrectDownload() {
         val project = Project("owner", "someName", "https://github.com/cqfn/save.git", "descr").apply {
@@ -168,7 +166,7 @@ class DownloadProjectTest(
         assertions.orTimeout(60, TimeUnit.SECONDS).join().forEach { Assertions.assertNotNull(it) }
     }
 
-    @Suppress("TOO_LONG_FUNCTION", "LongMethod")
+    @Suppress("LongMethod")
     @Test
     fun testSaveProjectAsBinaryFile() {
         File(binFolder).mkdirs()
@@ -237,7 +235,6 @@ class DownloadProjectTest(
     }
 
     @Test
-    @Suppress("TOO_LONG_FUNCTION")
     fun testStandardTestSuites() {
         val requestSize = readStandardTestSuitesFile(configProperties.reposFileName)
             .toList()
@@ -360,6 +357,8 @@ class DownloadProjectTest(
     }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(DownloadProjectTest::class.java)
+
         @JvmStatic
         lateinit var mockServerBackend: MockWebServer
 

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -308,17 +308,21 @@ class DownloadProjectTest(
         }
         val request = ExecutionRequest(project, GitDto("https://github.com/cqfn/save"), "examples/kotlin-diktat/save.properties", Sdk.Default, execution.id)
 
+        // /updateExecution
+        mockServerBackend.enqueue(
+            MockResponse().setResponseCode(200)
+        )
+        // /cleanup
+        mockServerOrchestrator.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
         // /execution
         mockServerBackend.enqueue(
             MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
                 .setBody(objectMapper.writeValueAsString(execution))
-        )
-        // /cleanup
-        mockServerOrchestrator.enqueue(
-            MockResponse()
-                .setResponseCode(200)
         )
         // /saveTestSuites
         mockServerBackend.enqueue(
@@ -344,9 +348,10 @@ class DownloadProjectTest(
         val assertions = CompletableFuture.supplyAsync {
             listOf(
                 mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
-                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
-                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
                 mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
                 mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
             )
         }

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -315,7 +315,7 @@ class DownloadProjectTest(
                 .setHeader("Content-Type", "application/json")
                 .setBody(objectMapper.writeValueAsString(execution))
         )
-        // /celanup
+        // /cleanup
         mockServerOrchestrator.enqueue(
             MockResponse()
                 .setResponseCode(200)

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -347,14 +347,16 @@ class DownloadProjectTest(
                 .setResponseCode(200)
         )
         val assertions = CompletableFuture.supplyAsync {
-            listOf(
+            sequenceOf(
                 mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
                 mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
                 mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
                 mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
                 mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
                 mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
-            )
+            ).onEach {
+                logger.info("Request $it")
+            }
         }
 
         webClient.post()
@@ -366,9 +368,8 @@ class DownloadProjectTest(
             .isAccepted
             .expectBody<String>()
             .isEqualTo("Clone pending")
-        Thread.sleep(2500)
 
-        assertions.orTimeout(60, TimeUnit.SECONDS).join().forEach { Assertions.assertNotNull(it) }
+        assertions.orTimeout(360, TimeUnit.SECONDS).join().forEach { Assertions.assertNotNull(it) }
     }
 
     @AfterEach

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.QueueDispatcher
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
@@ -276,6 +279,74 @@ class DownloadProjectTest(
         Thread.sleep(2500)
         assertions.orTimeout(60, TimeUnit.SECONDS).join().forEach { Assertions.assertNotNull(it) }
         Assertions.assertTrue(File("${configProperties.repository}/${"https://github.com/cqfn/save".hashCode()}").exists())
+    }
+
+    @Test
+    fun `rerun execution`() {
+        val project = Project("owner", "someName", null, "descr").apply {
+            id = 42L
+        }
+        val execution = Execution(project, LocalDateTime.now(), LocalDateTime.now(), ExecutionStatus.PENDING, "1",
+            "foo", 0, 20, ExecutionType.GIT, "0.0.1", 0, 0, 0, Sdk.Default.toString()).apply {
+            id = 98L
+        }
+        val request = ExecutionRequest(project, GitDto("https://github.com/cqfn/save"), "examples/kotlin-diktat/save.properties", Sdk.Default, execution.id)
+
+        // /execution
+        mockServerBackend.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(objectMapper.writeValueAsString(execution))
+        )
+        // /celanup
+        mockServerOrchestrator.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        // /saveTestSuites
+        mockServerBackend.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(objectMapper.writeValueAsString(
+                    listOf(
+                        TestSuite(TestSuiteType.PROJECT, "", project, LocalDateTime.now(), "save.properties")
+                    )
+                )),
+        )
+        // /initializeTests?executionId=$executionId
+        mockServerBackend.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        // /initializeAgents
+        mockServerOrchestrator.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+        )
+        val assertions = CompletableFuture.supplyAsync {
+            listOf(
+                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
+                mockServerBackend.takeRequest(60, TimeUnit.SECONDS),
+                mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
+                mockServerOrchestrator.takeRequest(60, TimeUnit.SECONDS),
+            )
+        }
+
+        webClient.post()
+            .uri("/rerunExecution")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus()
+            .isAccepted
+            .expectBody<String>()
+            .isEqualTo("Clone pending")
+        Thread.sleep(2500)
+
+        assertions.orTimeout(60, TimeUnit.SECONDS).join().forEach { Assertions.assertNotNull(it) }
     }
 
     @AfterEach


### PR DESCRIPTION
### What's done:
* Added endpoint in backend
* Added button on frontend
* Logic in preprocessor
* Endpoint for cleanup in orchestrator

This change covers only executions with type `GIT`. Executions with type `STANDARD` need to be covered separately, after they are supported in #199 

Caveats:
* TestRootPath is deduced for executions with `testSuiteIds == ALL` based on their proeprties file path. This seems like a hack and needs to be sorted along with #205 
* Current implementation discards all artifacts from previous runs (cloned repo, image, container)

Closes #216