### PR TITLE
Persistent file storage

### DIFF
--- a/docker-compose.yaml.template
+++ b/docker-compose.yaml.template
@@ -39,6 +39,8 @@ services:
     secrets:
       - db_username
       - db_password
+    volumes:
+      - save-fs-storage:/home/cnb/
     ports:
       - "5000:5000"
     deploy:
@@ -101,6 +103,7 @@ services:
 
 volumes:
   save:
+  save-fs-storage:
   grafana-storage:
   prometheus-storage:
   loki-storage:

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/CloneRepositoryController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/CloneRepositoryController.kt
@@ -20,7 +20,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.client.MultipartBodyBuilder
-import org.springframework.http.codec.multipart.FilePart
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/CloneRepositoryController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/CloneRepositoryController.kt
@@ -133,7 +133,7 @@ class CloneRepositoryController(
         .toEntity<String>()
 
     private fun Flux<FileInfo>.collectToMultipart(multipartBodyBuilder: MultipartBodyBuilder) = map {
-        multipartBodyBuilder.part("file", fileSystemRepository.getFile(it.name))
+        multipartBodyBuilder.part("file", fileSystemRepository.getFile(it))
     }
         .collectList()
         .switchIfEmpty(Mono.just(emptyList()))

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
@@ -9,8 +9,8 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.codec.multipart.FilePart
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
@@ -41,18 +41,18 @@ class DownloadFilesController(
     }
 
     /**
-     * @param name name of a file to download
+     * @param fileInfo a FileInfo based on which a file should be located
      * @return [Mono] with file contents
      */
-    @GetMapping(value = ["/files/download/{name}"], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
-    fun download(@PathVariable("name") name: String): Mono<ByteArrayResponse> = Mono.fromCallable {
-        logger.info("Sending file $name to a client")
+    @GetMapping(value = ["/files/download"], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
+    fun download(@RequestBody fileInfo: FileInfo): Mono<ByteArrayResponse> = Mono.fromCallable {
+        logger.info("Sending file ${fileInfo.name} to a client")
         ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM).body(
-            fileSystemRepository.getFile(name).inputStream.readAllBytes()
+            fileSystemRepository.getFile(fileInfo).inputStream.readAllBytes()
         )
     }
         .doOnError(FileNotFoundException::class.java) {
-            logger.warn("File $name is not found", it)
+            logger.warn("File $fileInfo is not found", it)
         }
         .onErrorReturn(
             FileNotFoundException::class.java,

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/controllers/DownloadFilesController.kt
@@ -71,10 +71,10 @@ class DownloadFilesController(
      */
     @PostMapping(value = ["/files/upload"], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun upload(@RequestPart("file") file: Mono<FilePart>) =
-            fileSystemRepository.saveFile(file).map { size ->
+            fileSystemRepository.saveFile(file).map { fileInfo ->
                 ResponseEntity.status(
-                    if (size > 0) HttpStatus.OK else HttpStatus.INTERNAL_SERVER_ERROR
+                    if (fileInfo.sizeBytes > 0) HttpStatus.OK else HttpStatus.INTERNAL_SERVER_ERROR
                 )
-                    .body("Saved $size bytes")
+                    .body(fileInfo)
             }
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/FileSystemRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/FileSystemRepository.kt
@@ -1,6 +1,7 @@
 package org.cqfn.save.backend.repository
 
 import org.cqfn.save.backend.configs.ConfigProperties
+import org.cqfn.save.domain.FileInfo
 import org.springframework.core.io.FileSystemResource
 import org.springframework.http.codec.multipart.FilePart
 import org.springframework.stereotype.Repository
@@ -14,6 +15,7 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
 import kotlin.io.path.exists
 import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
 import kotlin.io.path.notExists
 import kotlin.io.path.outputStream
 
@@ -52,7 +54,8 @@ class FileSystemRepository(configProperties: ConfigProperties) {
      * @param parts file parts
      * @return Mono with number of bytes saved
      */
-    fun saveFile(parts: Mono<FilePart>): Mono<Long> = parts.flatMap { part ->
+    fun saveFile(parts: Mono<FilePart>): Mono<FileInfo> = parts.flatMap { part ->
+        val uploadedMillis = System.currentTimeMillis()
         rootDir.resolve(part.filename()).run {
             if (notExists()) {
                 createFile()
@@ -65,6 +68,9 @@ class FileSystemRepository(configProperties: ConfigProperties) {
                 }
             }
                 .collect(Collectors.summingLong { it })
+                .map {
+                    FileInfo(name, uploadedMillis, it)
+                }
         }
     }
 }

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/FileSystemRepository.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/repository/FileSystemRepository.kt
@@ -47,7 +47,7 @@ class FileSystemRepository(configProperties: ConfigProperties) {
      * @param file a file to save
      */
     fun saveFile(file: Path) {
-        file.copyTo(rootDir, overwrite = false)
+        file.copyTo(rootDir.resolve(file.name), overwrite = false)
     }
 
     /**

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
@@ -59,8 +59,8 @@ import kotlin.io.path.writeLines
 class DownloadFilesTest {
     @Autowired
     lateinit var webTestClient: WebTestClient
-    @Autowired private lateinit var fileSystemRepository: FileSystemRepository
-
+    @Autowired
+    private lateinit var fileSystemRepository: FileSystemRepository
     @Autowired
     private lateinit var configProperties: ConfigProperties
 

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
@@ -114,10 +114,10 @@ class DownloadFilesTest {
             .body(BodyInserters.fromMultipartData(body))
             .exchange()
             .expectStatus().isOk
-            .expectBody<String>().consumeWith {
-                Assertions.assertLinesMatch(
-                    listOf("Saved \\d+ bytes"),
-                    listOf(it.responseBody)
+            .expectBody<FileInfo>()
+            .consumeWith {
+                Assertions.assertTrue(
+                    it.responseBody!!.sizeBytes > 0
                 )
             }
     }

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/DownloadFilesTest.kt
@@ -59,8 +59,10 @@ import kotlin.io.path.writeLines
 class DownloadFilesTest {
     @Autowired
     lateinit var webTestClient: WebTestClient
+    
     @Autowired
     private lateinit var fileSystemRepository: FileSystemRepository
+    
     @Autowired
     private lateinit var configProperties: ConfigProperties
 

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
@@ -5,6 +5,7 @@ import org.cqfn.save.backend.controllers.CloneRepositoryController
 import org.cqfn.save.backend.repository.AgentRepository
 import org.cqfn.save.backend.repository.AgentStatusRepository
 import org.cqfn.save.backend.repository.ExecutionRepository
+import org.cqfn.save.backend.repository.FileSystemRepository
 import org.cqfn.save.backend.repository.GitRepository
 import org.cqfn.save.backend.repository.ProjectRepository
 import org.cqfn.save.backend.repository.TestExecutionRepository
@@ -13,17 +14,14 @@ import org.cqfn.save.backend.repository.TestSuiteRepository
 import org.cqfn.save.backend.service.ExecutionService
 import org.cqfn.save.backend.service.ProjectService
 import org.cqfn.save.domain.Jdk
+import org.cqfn.save.domain.toFileInfo
 import org.cqfn.save.entities.ExecutionRequest
 import org.cqfn.save.entities.ExecutionRequestForStandardSuites
 import org.cqfn.save.entities.GitDto
 import org.cqfn.save.entities.Project
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.cqfn.save.backend.repository.FileSystemRepository
-import org.cqfn.save.domain.FileInfo
-import org.cqfn.save.domain.toFileInfo
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,7 +34,6 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.mock.mockito.MockBeans
 import org.springframework.context.annotation.Import
-import org.springframework.core.io.FileSystemResource
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.client.MultipartBodyBuilder
@@ -46,9 +43,9 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.web.reactive.function.BodyInserters
 
-import java.io.File
 import java.nio.file.Path
 import java.time.Duration
+
 import kotlin.io.path.createFile
 
 @WebFluxTest(controllers = [CloneRepositoryController::class])
@@ -66,9 +63,8 @@ import kotlin.io.path.createFile
     MockBean(ProjectRepository::class),
     MockBean(GitRepository::class),
 )
+@Suppress("TOO_LONG_FUNCTION")
 class CloningRepositoryControllerTest {
-    @Autowired private lateinit var objectMapper: ObjectMapper
-
     @Autowired private lateinit var fileSystemRepository: FileSystemRepository
 
     @Autowired

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/CloningRepositoryControllerTest.kt
@@ -112,7 +112,6 @@ class CloningRepositoryControllerTest {
     @Test
     fun checkNewJobResponseForBin() {
         val binFile = tmpDir.resolve("binFile").apply {
-            println("Creating $this")
             createFile()
         }
         val property = tmpDir.resolve("property").apply {

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/domain/FileInfoJvm.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/domain/FileInfoJvm.kt
@@ -1,3 +1,7 @@
+/**
+ * Utils for `FileInfo` on JVM
+ */
+
 package org.cqfn.save.domain
 
 import java.io.File
@@ -6,6 +10,12 @@ import kotlin.io.path.fileSize
 import kotlin.io.path.getLastModifiedTime
 import kotlin.io.path.name
 
+/**
+ * @return a [File] with same name as `this`
+ */
 fun FileInfo.toFile(): File = File(name)
 
+/**
+ * @return [FileInfo] constructed from `this` [Path]
+ */
 fun Path.toFileInfo() = FileInfo(name, getLastModifiedTime().toMillis(), fileSize())

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/domain/FileInfoJvm.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/domain/FileInfoJvm.kt
@@ -1,0 +1,11 @@
+package org.cqfn.save.domain
+
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.fileSize
+import kotlin.io.path.getLastModifiedTime
+import kotlin.io.path.name
+
+fun FileInfo.toFile(): File = File(name)
+
+fun Path.toFileInfo() = FileInfo(name, getLastModifiedTime().toMillis(), fileSize())

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         binaries.executable()  // already default for LEGACY, but explicitly needed for IR
         sourceSets.all {
             languageSettings.optIn("kotlin.RequiresOptIn")
+            languageSettings.optIn("kotlinx.serialization.ExperimentalSerializationApi")
         }
         sourceSets["main"].dependencies {
             implementation(project(":save-cloud-common"))

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -20,6 +20,7 @@ import org.cqfn.save.frontend.externals.fontawesome.faCheck
 import org.cqfn.save.frontend.externals.fontawesome.faCogs
 import org.cqfn.save.frontend.externals.fontawesome.faExclamationTriangle
 import org.cqfn.save.frontend.externals.fontawesome.faSignOutAlt
+import org.cqfn.save.frontend.externals.fontawesome.faTimesCircle
 import org.cqfn.save.frontend.externals.fontawesome.faUser
 import org.cqfn.save.frontend.externals.fontawesome.fas
 import org.cqfn.save.frontend.externals.fontawesome.library
@@ -111,7 +112,7 @@ class App : RComponent<PropsWithChildren, AppState>() {
 fun main() {
     kotlinext.js.require("../scss/save-frontend.scss")  // this is needed for webpack to include resource
     kotlinext.js.require("bootstrap")  // this is needed for webpack to include bootstrap
-    library.add(fas, faUser, faCogs, faSignOutAlt, faAngleUp, faCheck, faExclamationTriangle)
+    library.add(fas, faUser, faCogs, faSignOutAlt, faAngleUp, faCheck, faExclamationTriangle, faTimesCircle)
     ReactModal.setAppElement(document.getElementById("wrapper") as HTMLElement)  // required for accessibility in react-modal
 
     render(document.getElementById("wrapper")) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
@@ -9,6 +9,7 @@ package org.cqfn.save.frontend.components.basic
 import org.cqfn.save.domain.FileInfo
 import org.cqfn.save.frontend.externals.fontawesome.faTimesCircle
 import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+import org.cqfn.save.frontend.utils.toPrettyString
 
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLSelectElement
@@ -27,14 +28,10 @@ import react.dom.strong
 import react.dom.ul
 import react.fc
 
-import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import kotlinx.html.InputType
 import kotlinx.html.hidden
 import kotlinx.html.js.onChangeFunction
 import kotlinx.html.js.onClickFunction
-import org.cqfn.save.frontend.utils.toPrettyString
 
 /**
  * Props for file uploader
@@ -57,6 +54,7 @@ external interface UploaderProps : PropsWithChildren {
  * @param onFileRemove invoked when a file is removed from selection by pushing a button
  * @return a RComponent
  */
+@Suppress("TOO_LONG_FUNCTION")
 fun fileUploader(
     onFileSelect: (HTMLSelectElement) -> Unit,
     onFileRemove: (FileInfo) -> Unit,

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
@@ -82,7 +82,7 @@ fun fileUploader(
                     }
                 }
                 li("list-group-item d-flex justify-content-between align-items-center") {
-                    select {
+                    select(classes = "form-control") {
                         option {
                             attrs.disabled = true
                             attrs.selected = true

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
@@ -86,7 +86,7 @@ fun fileUploader(
                             attrs.selected = true
                             +"Select a file from existing"
                         }
-                        props.availableFiles.map {
+                        props.availableFiles.sortedByDescending { it.uploadedMillis }.map {
                             option("list-group-item") {
                                 attrs.value = it.name
                                 +it.toPrettyString()

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
@@ -6,56 +6,116 @@
 
 package org.cqfn.save.frontend.components.basic
 
+import org.cqfn.save.domain.FileInfo
+import org.cqfn.save.frontend.externals.fontawesome.faTimesCircle
+import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+
 import org.w3c.dom.HTMLInputElement
-import org.w3c.files.File
+import org.w3c.dom.HTMLSelectElement
 import react.PropsWithChildren
 import react.dom.attrs
+import react.dom.button
 import react.dom.div
 import react.dom.h6
 import react.dom.img
 import react.dom.input
 import react.dom.label
+import react.dom.li
+import react.dom.option
+import react.dom.select
 import react.dom.strong
+import react.dom.ul
 import react.fc
 
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.html.InputType
 import kotlinx.html.hidden
 import kotlinx.html.js.onChangeFunction
+import kotlinx.html.js.onClickFunction
 
 /**
  * Props for file uploader
  */
 external interface UploaderProps : PropsWithChildren {
     /**
+     * List of files available on server side
+     */
+    var availableFiles: List<FileInfo>
+
+    /**
      * List of provided files
      */
-    var files: List<File>
+    var files: List<FileInfo>
 }
 
 /**
- * @param handler invoked on `input` change events
+ * @param onFileInput invoked on `input` change events
+ * @param onFileSelect invoked when a file is selected from [UploaderProps.availableFiles]
+ * @param onFileRemove invoked when a file is removed from selection by pushing a button
  * @return a RComponent
  */
-fun fileUploader(handler: (HTMLInputElement) -> Unit) = fc<UploaderProps> { props ->
+fun fileUploader(
+    onFileSelect: (HTMLSelectElement) -> Unit,
+    onFileRemove: (FileInfo) -> Unit,
+    onFileInput: (HTMLInputElement) -> Unit
+) = fc<UploaderProps> { props ->
     div("mb-3") {
         h6(classes = "d-inline mr-3") {
             +"Select files:"
         }
         div {
-            label {
-                input(type = InputType.file) {
-                    attrs.multiple = true
-                    attrs.hidden = true
-                    attrs {
-                        onChangeFunction = { event ->
-                            val target = event.target as HTMLInputElement
-                            handler(target)
+            ul(classes = "list-group") {
+                props.files.map { fileInfo ->
+                    li(classes = "list-group-item") {
+                        button(classes = "btn") {
+                            fontAwesomeIcon {
+                                attrs.icon = faTimesCircle
+                            }
+                            attrs.onClickFunction = {
+                                onFileRemove(fileInfo)
+                            }
+                        }
+                        +"$fileInfo"
+                    }
+                }
+                li("list-group-item d-flex justify-content-between align-items-center") {
+                    select {
+                        option {
+                            attrs.disabled = true
+                            attrs.selected = true
+                            +"Select a file from existing"
+                        }
+                        props.availableFiles.map {
+                            option("list-group-item") {
+                                attrs.value = it.name
+                                +"${it.name} (uploaded ${
+                                    Instant.fromEpochMilliseconds(it.uploadedMillis).toLocalDateTime(
+                                        TimeZone.UTC)}, size ${it.sizeBytes / 1024} KiB)"
+                            }
+                        }
+                        attrs.onChangeFunction = {
+                            onFileSelect(it.target as HTMLSelectElement)
                         }
                     }
                 }
-                img(classes = "img-upload", src = "img/upload.svg") {}
-                strong { +"Upload files:" }
-                +props.files.joinToString { it.name }
+                li("list-group-item d-flex justify-content-between align-items-center") {
+                    label {
+                        input(type = InputType.file) {
+                            attrs.multiple = true
+                            attrs.hidden = true
+                            attrs {
+                                onChangeFunction = { event ->
+                                    val target = event.target as HTMLInputElement
+                                    onFileInput(target)
+                                }
+                            }
+                        }
+                        img(classes = "img-upload", src = "img/upload.svg") {}
+                        strong { +"Upload files:" }
+                    }
+                }
             }
         }
     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/FileUploader.kt
@@ -34,6 +34,7 @@ import kotlinx.html.InputType
 import kotlinx.html.hidden
 import kotlinx.html.js.onChangeFunction
 import kotlinx.html.js.onClickFunction
+import org.cqfn.save.frontend.utils.toPrettyString
 
 /**
  * Props for file uploader
@@ -77,7 +78,7 @@ fun fileUploader(
                                 onFileRemove(fileInfo)
                             }
                         }
-                        +"$fileInfo"
+                        +fileInfo.toPrettyString()
                     }
                 }
                 li("list-group-item d-flex justify-content-between align-items-center") {
@@ -90,9 +91,7 @@ fun fileUploader(
                         props.availableFiles.map {
                             option("list-group-item") {
                                 attrs.value = it.name
-                                +"${it.name} (uploaded ${
-                                    Instant.fromEpochMilliseconds(it.uploadedMillis).toLocalDateTime(
-                                        TimeZone.UTC)}, size ${it.sizeBytes / 1024} KiB)"
+                                +it.toPrettyString()
                             }
                         }
                         attrs.onChangeFunction = {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -411,13 +411,11 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
                                 files.remove(it)
                             }
                         }) { htmlInputElement ->
-                            setState {
-                                files = htmlInputElement.files!!.asList().map {
-                                    FileInfo(it.name, it.lastModified.toLong(), it.size.toLong())
-                                }.toMutableList()
-                            }
                             GlobalScope.launch {
                                 htmlInputElement.files!!.asList().forEach { file ->
+                                    setState {
+                                        isLoading = true
+                                    }
                                     val response: FileInfo = post(
                                         "${window.location.origin}/files/upload",
                                         Headers(),
@@ -426,8 +424,11 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
                                         }
                                     )
                                         .decodeFromJsonString()
-                                    state.availableFiles.add(response)
-                                    state.files.add(response)
+                                    setState {
+                                        availableFiles.add(response)
+                                        files.add(response)
+                                        isLoading = false
+                                    }
                                 }
                             }
                         }) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -41,8 +41,8 @@ import react.dom.button
 import react.dom.defaultValue
 import react.dom.div
 import react.dom.h1
-import react.dom.h4
 import react.dom.h6
+import react.dom.i
 import react.dom.input
 import react.dom.p
 import react.dom.span
@@ -466,18 +466,14 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
                 child(cardComponent {
                     div("ml-3") {
                         h6("d-inline") {
-                            +"Name: "
-                        }
-                        h4("d-inline") {
+                            i { +"Name: " }
                             +project.name
                         }
                     }
                     div("ml-3") {
                         h6("d-inline") {
-                            +"Description: "
-                        }
-                        h4("d-inline") {
-                            +"${project.description}"
+                            i { +"Description: " }
+                            +(project.description ?: "")
                         }
                     }
                     p {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -59,6 +59,7 @@ import kotlinx.html.classes
 import kotlinx.html.js.onChangeFunction
 import kotlinx.html.js.onClickFunction
 import kotlinx.html.role
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -213,10 +214,9 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
         val selectedSdk = "${state.selectedSdk}:${state.selectedSdkVersion}".toSdk()
         val request = ExecutionRequestForStandardSuites(project, selectedTypes, selectedSdk)
         formData.append("execution", Blob(arrayOf(Json.encodeToString(request)), BlobPropertyBag("application/json")))
-        // todo!
-        // state.files.forEach {
-        // formData.append("file", it)
-        // }
+        state.files.forEach {
+           formData.append("file", Json.encodeToString(it))
+        }
         submitRequest("/submitExecutionRequestBin", headers, formData)
     }
 
@@ -238,10 +238,9 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
             executionId = null)
         val jsonExecution = Json.encodeToString(executionRequest)
         formData.append("executionRequest", Blob(arrayOf(jsonExecution), BlobPropertyBag("application/json")))
-        // todo!
-        // state.files.forEach {
-        // formData.append("file", it)
-        // }
+         state.files.forEach {
+            formData.append("file", Json.encodeToString(it))
+         }
         submitRequest("/submitExecutionRequest", Headers(), formData)
     }
 

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -18,6 +18,7 @@ import org.cqfn.save.frontend.components.basic.checkBoxGrid
 import org.cqfn.save.frontend.components.basic.fileUploader
 import org.cqfn.save.frontend.components.basic.sdkSelection
 import org.cqfn.save.frontend.externals.modal.modal
+import org.cqfn.save.frontend.utils.appendJson
 import org.cqfn.save.frontend.utils.decodeFromJsonString
 import org.cqfn.save.frontend.utils.get
 import org.cqfn.save.frontend.utils.getProject
@@ -58,7 +59,6 @@ import kotlinx.html.js.onClickFunction
 import kotlinx.html.role
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.cqfn.save.frontend.utils.appendJson
 
 /**
  * `Props` retrieved from router
@@ -212,7 +212,7 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
         val request = ExecutionRequestForStandardSuites(project, selectedTypes, selectedSdk)
         formData.appendJson("execution", request)
         state.files.forEach {
-           formData.appendJson("file", it)
+            formData.appendJson("file", it)
         }
         submitRequest("/submitExecutionRequestBin", headers, formData)
     }
@@ -234,9 +234,9 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
             sdk = selectedSdk,
             executionId = null)
         formData.appendJson("executionRequest", executionRequest)
-         state.files.forEach {
-             formData.appendJson("file", it)
-         }
+        state.files.forEach {
+            formData.appendJson("file", it)
+        }
         submitRequest("/submitExecutionRequest", Headers(), formData)
     }
 

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -234,14 +234,11 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
             correctGitDto,
             sdk = selectedSdk,
             executionId = null)
-        val jsonExecution = Json.encodeToString(executionRequest)
-        formData.appendJson("executionRequest", jsonExecution)
+        formData.appendJson("executionRequest", executionRequest)
          state.files.forEach {
              formData.appendJson("file", it)
          }
-        submitRequest("/submitExecutionRequest", Headers().apply {
-            append("Accept", "text/plain")
-        }, formData)
+        submitRequest("/submitExecutionRequest", Headers(), formData)
     }
 
     private fun submitRequest(url: String, headers: Headers, body: dynamic) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -29,14 +29,11 @@ import org.cqfn.save.testsuite.TestSuiteDto
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.asList
 import org.w3c.fetch.Headers
-import org.w3c.files.Blob
-import org.w3c.files.BlobPropertyBag
 import org.w3c.xhr.FormData
 import react.PropsWithChildren
 import react.RBuilder
 import react.RComponent
 import react.State
-import react.child
 import react.dom.a
 import react.dom.attrs
 import react.dom.button
@@ -62,6 +59,7 @@ import kotlinx.html.role
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.cqfn.save.frontend.utils.appendJson
 
 /**
  * [RProps] retrieved from router
@@ -213,9 +211,9 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
         val formData = FormData()
         val selectedSdk = "${state.selectedSdk}:${state.selectedSdkVersion}".toSdk()
         val request = ExecutionRequestForStandardSuites(project, selectedTypes, selectedSdk)
-        formData.append("execution", Blob(arrayOf(Json.encodeToString(request)), BlobPropertyBag("application/json")))
+        formData.appendJson("execution", request)
         state.files.forEach {
-           formData.append("file", Json.encodeToString(it))
+           formData.appendJson("file", it)
         }
         submitRequest("/submitExecutionRequestBin", headers, formData)
     }
@@ -237,11 +235,13 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
             sdk = selectedSdk,
             executionId = null)
         val jsonExecution = Json.encodeToString(executionRequest)
-        formData.append("executionRequest", Blob(arrayOf(jsonExecution), BlobPropertyBag("application/json")))
+        formData.appendJson("executionRequest", jsonExecution)
          state.files.forEach {
-            formData.append("file", Json.encodeToString(it))
+             formData.appendJson("file", it)
          }
-        submitRequest("/submitExecutionRequest", Headers(), formData)
+        submitRequest("/submitExecutionRequest", Headers().apply {
+            append("Accept", "text/plain")
+        }, formData)
     }
 
     private fun submitRequest(url: String, headers: Headers, body: dynamic) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/Icons.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/Icons.kt
@@ -14,3 +14,4 @@ external val faSignOutAlt: dynamic
 external val faAngleUp: dynamic
 external val faCheck: dynamic
 external val faExclamationTriangle: dynamic
+external val faTimesCircle: dynamic

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
@@ -4,9 +4,23 @@ import org.cqfn.save.domain.FileInfo
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.w3c.files.Blob
+import org.w3c.files.BlobPropertyBag
+import org.w3c.xhr.FormData
 
 fun FileInfo.toPrettyString() = "$name (uploaded at ${
     Instant.fromEpochMilliseconds(uploadedMillis).toLocalDateTime(
         TimeZone.UTC
     )
 }, size ${sizeBytes / 1024} KiB)"
+
+inline fun <reified T> FormData.appendJson(name: String, obj: T) =
+    append(
+        name,
+        Blob(
+            arrayOf(Json.encodeToString(obj)),
+            BlobPropertyBag("application/json")
+        )
+    )

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
@@ -1,26 +1,43 @@
+/**
+ * Various utils for frontend
+ */
+
 package org.cqfn.save.frontend.utils
 
 import org.cqfn.save.domain.FileInfo
+
+import org.w3c.files.Blob
+import org.w3c.files.BlobPropertyBag
+import org.w3c.xhr.FormData
+
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.w3c.files.Blob
-import org.w3c.files.BlobPropertyBag
-import org.w3c.xhr.FormData
 
+/**
+ * @return a nicely formatted string representation of [FileInfo]
+ */
+@Suppress("MAGIC_NUMBER", "MagicNumber")
 fun FileInfo.toPrettyString() = "$name (uploaded at ${
     Instant.fromEpochMilliseconds(uploadedMillis).toLocalDateTime(
         TimeZone.UTC
     )
 }, size ${sizeBytes / 1024} KiB)"
 
+/**
+ * Append an object [obj] to `this` [FormData] as a JSON, using kx.serialization for serialization
+ *
+ * @param name key to be appended to the form data
+ * @param obj an object to be appended
+ * @return Unit
+ */
 inline fun <reified T> FormData.appendJson(name: String, obj: T) =
-    append(
-        name,
-        Blob(
-            arrayOf(Json.encodeToString(obj)),
-            BlobPropertyBag("application/json")
+        append(
+            name,
+            Blob(
+                arrayOf(Json.encodeToString(obj)),
+                BlobPropertyBag("application/json")
+            )
         )
-    )

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/utils/Utils.kt
@@ -1,0 +1,12 @@
+package org.cqfn.save.frontend.utils
+
+import org.cqfn.save.domain.FileInfo
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+fun FileInfo.toPrettyString() = "$name (uploaded at ${
+    Instant.fromEpochMilliseconds(uploadedMillis).toLocalDateTime(
+        TimeZone.UTC
+    )
+}, size ${sizeBytes / 1024} KiB)"

--- a/save-frontend/webpack.config.d/dev-server.js
+++ b/save-frontend/webpack.config.d/dev-server.js
@@ -1,0 +1,12 @@
+config.devServer = Object.assign(
+    {},
+    config.devServer || {},
+    {
+      proxy: [
+        {
+          context: ["/**"],
+          target: 'http://localhost:5000',
+        }
+      ]
+    }
+)


### PR DESCRIPTION
### What's done:
* Upload file after submission from frontend
* Return FileInfo after uploading file
* Select files from the list of available
* Accept Flux of `FileInfo`s on backend in `/submit*` handlers
* Added devServer proxy for local development of save-frontend
* Make fonts in ProjectView on the right side smaller

### TODO:
* [x] Re-render after upload finishes (check, if new files are added to availableFiles)
* [x] Wait for /upload to complete, disable submission while it's in progress
* [x] Remove already selected files from the list of available
* [ ] Don't upload same files (check on backend in `/upload`: if name, content hash and modified timestamps are equal, return 4xx code or something) (maybe it's better to check on frontend?) for now 409 can be returned if file hasn't been saved because it already exists
* [x] Add FileSystemRepository storage to docker volume
* [x] Add `uploadDate` to FileInfo

Closes #210