### PR TITLE
Hotfix: Update usage of SAVE api in preprocessor after latest changes

### DIFF
--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
@@ -81,10 +81,10 @@ class TestDiscoveringService {
             plugins.flatMap { plugin ->
                 plugin.discoverTestFiles(testConfig.directory)
                     .map {
-                        val testRelativePath = it.first().toFile()
+                        val testRelativePath = it.test.toFile()
                             .relativeTo(rootTestConfig.directory.toFile())
                             .path
-                        TestDto(testRelativePath, plugin::class.simpleName!!, testSuite.id!!, it.first().toFile().toHash())
+                        TestDto(testRelativePath, plugin::class.simpleName!!, testSuite.id!!, it.test.toFile().toHash())
                     }
             }
         }


### PR DESCRIPTION
### What's done:
* Update usage of SAVE api in preprocessor after latest changes