### PR TITLE
Preprocessor: Close `Git` object

### DIFF
--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -141,7 +141,7 @@ class SaveAgent(private val config: AgentConfiguration,
     }
 
     private fun runSave(cliArgs: String): ExecutionResult = ProcessBuilder(true, FileSystem.SYSTEM)
-        .exec(config.cliCommand.let { if (cliArgs.isNotEmpty()) "$it $cliArgs" else it }, logFilePath.toPath())
+        .exec(config.cliCommand.let { if (cliArgs.isNotEmpty()) "$it $cliArgs" else it }, ".", logFilePath.toPath())
 
     @Suppress("TOO_MANY_LINES_IN_LAMBDA")
     private fun readExecutionResults(jsonFile: String): List<TestExecutionDto> {

--- a/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
+++ b/save-agent/src/linuxX64Main/kotlin/org/cqfn/save/agent/SaveAgent.kt
@@ -141,7 +141,7 @@ class SaveAgent(private val config: AgentConfiguration,
     }
 
     private fun runSave(cliArgs: String): ExecutionResult = ProcessBuilder(true, FileSystem.SYSTEM)
-        .exec(config.cliCommand.let { if (cliArgs.isNotEmpty()) "$it $cliArgs" else it }, ".", logFilePath.toPath())
+        .exec(config.cliCommand.let { if (cliArgs.isNotEmpty()) "$it $cliArgs" else it }, "", logFilePath.toPath())
 
     @Suppress("TOO_MANY_LINES_IN_LAMBDA")
     private fun readExecutionResults(jsonFile: String): List<TestExecutionDto> {

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -154,10 +154,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
         ResponseEntity("Clone pending", HttpStatus.ACCEPTED)
     }
         .doOnSuccess {
-            webClientBackend.makeRequest(
-                BodyInserters.fromValue(ExecutionUpdateDto(executionRerunRequest.executionId!!, ExecutionStatus.PENDING)),
-                "/updateExecution"
-            ) { it.toEntity<HttpStatus>() }
+            updateExecutionStatus(executionRerunRequest.executionId!!, ExecutionStatus.PENDING)
                 .flatMap {
                     cleanupInOrchestrator(executionRerunRequest.executionId!!)
                 }
@@ -193,6 +190,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
             val tmpDir = generateDirectory(listOf(testSuiteUrl))
             Mono.fromCallable {
                 cloneFromGit(GitDto(testSuiteUrl), tmpDir)
+                    .use { /* noop here, just need to close Git object */ }
             }
                 .flatMapMany { Flux.fromIterable(testSuitePaths) }
                 .flatMap { testRootPath ->
@@ -268,10 +266,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
                     is GitAPIException -> log.warn("Error with git API while cloning ${gitDto.url} repository", exception)
                     else -> log.warn("Cloning ${gitDto.url} repository failed", exception)
                 }
-                webClientBackend.makeRequest(
-                    BodyInserters.fromValue(ExecutionUpdateDto(executionRequest.executionId!!, ExecutionStatus.ERROR)),
-                    "/updateExecution"
-                ) { it.toEntity<HttpStatus>() }.flatMap {
+                updateExecutionStatus(executionRequest.executionId!!, ExecutionStatus.ERROR).flatMap {
                     Mono.error(exception)
                 }
             }
@@ -319,11 +314,17 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
         val hashName = seeds.hashCode()
         val tmpDir = File("${configProperties.repository}/$hashName")
         if (tmpDir.exists()) {
-            tmpDir.deleteRecursively()
-            log.info("For $seeds: dir $tmpDir was deleted")
+            if (tmpDir.deleteRecursively()) {
+                log.info("For $seeds: dir $tmpDir was deleted")
+            } else {
+                error("Couldn't properly delete $tmpDir")
+            }
         }
-        tmpDir.mkdirs()
-        log.info("For $seeds: dir $tmpDir was created")
+        if (tmpDir.mkdirs()) {
+            log.info("For $seeds: dir $tmpDir was created")
+        } else {
+            error("Couldn't create directories for $tmpDir")
+        }
         return tmpDir
     }
 
@@ -365,10 +366,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
                     "Error during preprocessing, will mark execution.id=${execution.id} as failed; error: ",
                     ex
                 )
-                webClientBackend.makeRequest(
-                    BodyInserters.fromValue(ExecutionUpdateDto(execution.id!!, ExecutionStatus.ERROR)),
-                    "/updateExecution"
-                ) { it.toEntity<HttpStatus>() }
+                updateExecutionStatus(execution.id!!, ExecutionStatus.ERROR)
             }
     }
 
@@ -441,7 +439,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
         val saveProperties: SaveProperties = decodeFromPropertiesFile<SaveProperties>(propertiesFile)
             .mergeConfigWithPriorityToThis(defaultConfig())
         return propertiesFile.parentFile
-            .resolve(saveProperties.testRootPath!!)
+            .resolve(saveProperties.testFiles!!.firstOrNull() ?: ".")
             .absolutePath
     }
 
@@ -514,6 +512,15 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
             .last()
     }
         .collectList()
+
+    private fun updateExecutionStatus(executionId: Long, executionStatus: ExecutionStatus) =
+            webClientBackend.makeRequest(
+                BodyInserters.fromValue(ExecutionUpdateDto(executionId, executionStatus)),
+                "/updateExecution"
+            ) { it.toEntity<HttpStatus>() }
+                .doOnSubscribe {
+                    log.info("Making request to set execution status for id=$executionId to $executionStatus")
+                }
 }
 
 /**

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -50,6 +50,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.web.reactive.function.BodyInserters
 
 import java.io.File
+import java.nio.charset.Charset
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.concurrent.CompletableFuture
@@ -385,11 +386,24 @@ class DownloadProjectTest(
 
     @AfterEach
     fun removeTestDir() {
-        File(configProperties.repository).deleteRecursively()
+        listOf(mockServerBackend, mockServerOrchestrator).forEach { server ->
+            server.dispatcher.peek().let { mockResponse ->
+                // when `QueueDispatcher.failFast` is true, default value is an empty response with code 404
+                val hasDefaultEnqueuedResponse =
+                        mockResponse.status == "HTTP/1.1 404 Client Error" && mockResponse.getBody() == null
+                require(hasDefaultEnqueuedResponse) {
+                    "There is an enqueued response in the MockServer after a test has completed. Enqueued body: " +
+                            "${
+                                mockResponse.getBody()?.readString(Charset.defaultCharset())
+                            }, status: ${mockResponse.status}"
+                }
+            }
+        }
     }
 
     @AfterAll
     fun removeBinDir() {
+        File(configProperties.repository).deleteRecursively()
         File(binFolder).deleteRecursively()
     }
 

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/utils/RepositoryVolume.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/utils/RepositoryVolume.kt
@@ -2,7 +2,6 @@ package org.cqfn.save.preprocessor.utils
 
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
-import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 
 /**
@@ -10,7 +9,6 @@ import kotlin.io.path.createTempDirectory
  */
 interface RepositoryVolume {
     companion object {
-        @OptIn(ExperimentalPathApi::class)
         private val volume: String by lazy {
             createTempDirectory("repositories").toAbsolutePath().toString()
         }


### PR DESCRIPTION
### What's done:
* Changed logic
* Minor refactoring

We didn't close `Git` object after it has been used, which sometimes lead to inability to delete directory. It may be the reason, why tests in preprocessor were flaky.