### PR TITLE
Orchestrator: Chown copied files to `cnb:cnb`

### DIFF
--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/controller/HeartbeatController.kt
@@ -19,6 +19,7 @@ import reactor.core.scheduler.Schedulers
 
 import java.time.LocalDateTime
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -47,6 +48,7 @@ class HeartbeatController(private val agentService: AgentService,
      * @return Answer for agent
      */
     @PostMapping("/heartbeat")
+    @OptIn(ExperimentalSerializationApi::class)
     fun acceptHeartbeat(@RequestBody heartbeat: Heartbeat): Mono<String> {
         logger.info("Got heartbeat state: ${heartbeat.state.name} from ${heartbeat.agentId}")
         // store new state into DB

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/AgentService.kt
@@ -11,7 +11,6 @@ import org.cqfn.save.entities.AgentStatusesForExecution
 import org.cqfn.save.execution.ExecutionStatus
 import org.cqfn.save.execution.ExecutionUpdateDto
 import org.cqfn.save.orchestrator.BodilessResponseEntity
-import org.cqfn.save.orchestrator.config.ConfigProperties
 import org.cqfn.save.test.TestBatch
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,7 +29,7 @@ import java.util.logging.Level
  * Service for work with agents and backend
  */
 @Service
-class AgentService(configProperties: ConfigProperties) {
+class AgentService {
     @Autowired
     @Qualifier("webClientBackend")
     private lateinit var webClientBackend: WebClient

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -20,6 +20,9 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.attribute.PosixFileAttributeView
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kotlin.io.path.ExperimentalPathApi
@@ -210,6 +213,11 @@ class DockerService(private val configProperties: ConfigProperties) {
                     .resolve(File(it.propertiesRelativePath).parent)
                 )
             standardTestSuiteAbsolutePath.copyRecursively(destination.resolve("${it.name}_${it.propertiesRelativePath.hashCode()}_${Random.nextInt()}"))
+        }
+        // orchestrator is executed as root (to access docker socket), but files are in a shared volume
+        Files.getFileAttributeView(destination.toPath(), PosixFileAttributeView::class.java, LinkOption.NOFOLLOW_LINKS).apply {
+            setGroup { "cnb" }
+            setOwner { "cnb" }
         }
     }
 

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -213,7 +213,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                 .resolve(File("${listOf(it.testSuiteRepoUrl!!).hashCode()}")
                     .resolve(File(it.propertiesRelativePath).parent)
                 )
-            log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $destination/...")
+            log.debug("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $destination/...")
             standardTestSuiteAbsolutePath.copyRecursively(destination.resolve("${it.name}_${it.propertiesRelativePath.hashCode()}_${Random.nextInt()}"))
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -206,12 +206,14 @@ class DockerService(private val configProperties: ConfigProperties) {
 
     @Suppress("UnsafeCallOnNullableType")
     private fun copyTestSuitesToResourcesPath(testSuitesForDocker: List<TestSuiteDto>, destination: File) {
+        log.info("Copying suites $testSuitesForDocker into $destination")
         testSuitesForDocker.forEach {
             val standardTestSuiteAbsolutePath = File(configProperties.testResources.basePath)
                 // tmp directories names for standard test suites constructs just by hashCode of listOf(repoUrl); reuse this logic
                 .resolve(File("${listOf(it.testSuiteRepoUrl!!).hashCode()}")
                     .resolve(File(it.propertiesRelativePath).parent)
                 )
+            log.info("Copying suite ${it.name} from $standardTestSuiteAbsolutePath into $destination/...")
             standardTestSuiteAbsolutePath.copyRecursively(destination.resolve("${it.name}_${it.propertiesRelativePath.hashCode()}_${Random.nextInt()}"))
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -221,7 +221,7 @@ class DockerService(private val configProperties: ConfigProperties) {
         destination.walk().forEach {
             Files.getFileAttributeView(it.toPath(), PosixFileAttributeView::class.java, LinkOption.NOFOLLOW_LINKS).apply {
                 setGroup(lookupService.lookupPrincipalByGroupName("cnb"))
-                owner = lookupService.lookupPrincipalByName("cnb")
+                setOwner(lookupService.lookupPrincipalByName("cnb"))
             }
         }
     }

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -206,7 +206,7 @@ class DockerService(private val configProperties: ConfigProperties) {
 
     @Suppress("UnsafeCallOnNullableType")
     private fun copyTestSuitesToResourcesPath(testSuitesForDocker: List<TestSuiteDto>, destination: File) {
-        log.info("Copying suites $testSuitesForDocker into $destination")
+        log.info("Copying suites ${testSuitesForDocker.map { it.name }} into $destination")
         testSuitesForDocker.forEach {
             val standardTestSuiteAbsolutePath = File(configProperties.testResources.basePath)
                 // tmp directories names for standard test suites constructs just by hashCode of listOf(repoUrl); reuse this logic

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -216,9 +216,11 @@ class DockerService(private val configProperties: ConfigProperties) {
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume
         val lookupService = destination.toPath().fileSystem.userPrincipalLookupService
-                Files.getFileAttributeView(destination.toPath(), PosixFileAttributeView::class.java, LinkOption.NOFOLLOW_LINKS).apply {
-            setGroup(lookupService.lookupPrincipalByGroupName("cnb"))
-            owner = lookupService.lookupPrincipalByName("cnb")
+        destination.walk().forEach {
+            Files.getFileAttributeView(it.toPath(), PosixFileAttributeView::class.java, LinkOption.NOFOLLOW_LINKS).apply {
+                setGroup(lookupService.lookupPrincipalByGroupName("cnb"))
+                owner = lookupService.lookupPrincipalByName("cnb")
+            }
         }
     }
 

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -215,9 +215,10 @@ class DockerService(private val configProperties: ConfigProperties) {
             standardTestSuiteAbsolutePath.copyRecursively(destination.resolve("${it.name}_${it.propertiesRelativePath.hashCode()}_${Random.nextInt()}"))
         }
         // orchestrator is executed as root (to access docker socket), but files are in a shared volume
-        Files.getFileAttributeView(destination.toPath(), PosixFileAttributeView::class.java, LinkOption.NOFOLLOW_LINKS).apply {
-            setGroup { "cnb" }
-            setOwner { "cnb" }
+        val lookupService = destination.toPath().fileSystem.userPrincipalLookupService
+                Files.getFileAttributeView(destination.toPath(), PosixFileAttributeView::class.java, LinkOption.NOFOLLOW_LINKS).apply {
+            setGroup(lookupService.lookupPrincipalByGroupName("cnb"))
+            owner = lookupService.lookupPrincipalByName("cnb")
         }
     }
 


### PR DESCRIPTION
### What's done:
* Updated logic

Orchestrator is executed as root (to access docker socket), but files are in a shared volume, so they need to have correct ownership.