### PR TITLE
Display description of test suites

### DIFF
--- a/db/changelog/v-2/03-changeset-test-suite.xml
+++ b/db/changelog/v-2/03-changeset-test-suite.xml
@@ -14,5 +14,8 @@
                 columnName="project_id"
                 columnDataType="bigint"
         />
+        <addColumn tableName="test_suite">
+            <column name="description" type="text"/>
+        </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,5 @@ org.gradle.vfs.watch=true
 # these two properties are for using platform.* API in nativeMain: https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-kotlin.native.cacheKind.linuxX64=static
+# caches are temporary disabled due to errors
+kotlin.native.cacheKind.linuxX64=none

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
@@ -51,7 +51,7 @@ class TestSuitesService {
                         }
                     }
             }
-            testSuiteRepository.saveAll(testSuites)
+        testSuiteRepository.saveAll(testSuites)
         return testSuites.toList()
     }
 

--- a/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
+++ b/save-backend/src/main/kotlin/org/cqfn/save/backend/service/TestSuitesService.kt
@@ -27,22 +27,31 @@ class TestSuitesService {
     @Suppress("UnsafeCallOnNullableType")
     fun saveTestSuite(testSuitesDto: List<TestSuiteDto>): List<TestSuite> {
         val testSuites = testSuitesDto
-            .map { TestSuite(it.type, it.name, it.project, null, it.propertiesRelativePath, it.testSuiteRepoUrl) }
+            .distinctBy {
+                // Same suites may be declared in different directories, we unify them here.
+                // We allow description of existing test suites to be changed.
+                it.copy(description = null)
+            }
+            .map {
+                TestSuite(it.type, it.name, it.description, it.project, null, it.propertiesRelativePath, it.testSuiteRepoUrl)
+            }
             .map { testSuite ->
                 // try to find TestSuite in the DB based on all non-null properties of `testSuite`
                 // NB: that's why `dateAdded` is null in the mapping above
-                testSuiteRepository.findOne(
-                    Example.of(testSuite)
-                )
-                    // if testSuite is not present in the DB, we will save it with current timestamp
+                val description = testSuite.description
+                testSuiteRepository
+                    .findOne(
+                        Example.of(testSuite.apply { this.description = null })
+                    )
                     .orElseGet {
+                        // if testSuite is not present in the DB, we will save it with current timestamp
                         testSuite.apply {
                             dateAdded = LocalDateTime.now()
+                            this.description = description
                         }
                     }
             }
-        testSuites.filter { it.id == null }
-            .let { testSuiteRepository.saveAll(it) }
+            testSuiteRepository.saveAll(testSuites)
         return testSuites.toList()
     }
 

--- a/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/TestSuitesControllerTest.kt
+++ b/save-backend/src/test/kotlin/org/cqfn/save/backend/controller/TestSuitesControllerTest.kt
@@ -64,6 +64,7 @@ class TestSuitesControllerTest {
         val testSuite = TestSuiteDto(
             TestSuiteType.PROJECT,
             "test",
+            null,
             project,
             "save.properties"
         )
@@ -86,6 +87,7 @@ class TestSuitesControllerTest {
         val testSuite = TestSuiteDto(
             TestSuiteType.PROJECT,
             "test",
+            null,
             project,
             "save.properties"
         )
@@ -104,6 +106,7 @@ class TestSuitesControllerTest {
         val testSuite = TestSuiteDto(
             TestSuiteType.PROJECT,
             "test",
+            null,
             project,
             "save.properties"
         )
@@ -116,6 +119,7 @@ class TestSuitesControllerTest {
         val testSuite2 = TestSuiteDto(
             TestSuiteType.PROJECT,
             "test2",
+            null,
             project,
             "save.properties"
         )
@@ -141,6 +145,7 @@ class TestSuitesControllerTest {
         val testSuite = TestSuiteDto(
             TestSuiteType.STANDARD,
             "tester",
+            null,
             project,
             "save.properties"
         )
@@ -169,6 +174,7 @@ class TestSuitesControllerTest {
         val testSuite = TestSuiteDto(
             TestSuiteType.STANDARD,
             name,
+            null,
             project,
             "save.properties"
         )

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/testsuite/TestSuiteDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/testsuite/TestSuiteDto.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.Serializable
 data class TestSuiteDto(
     val type: TestSuiteType?,
     val name: String,
+    val description: String?,
     val project: Project? = null,
     val propertiesRelativePath: String,
     val testSuiteRepoUrl: String? = null,

--- a/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/testsuite/TestSuiteDto.kt
+++ b/save-cloud-common/src/commonMain/kotlin/org/cqfn/save/testsuite/TestSuiteDto.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
  * @property project [TestSuite.project]
  * @property propertiesRelativePath [TestSuite.propertiesRelativePath]
  * @property testSuiteRepoUrl url of the repo with test suites
+ * @property description [TestSuite.description]
  */
 @Serializable
 data class TestSuiteDto(

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/TestSuite.kt
@@ -26,6 +26,8 @@ class TestSuite(
 
     var name: String = "FB",
 
+    var description: String? = "FB",
+
     @ManyToOne
     @JoinColumn(name = "project_id")
     var project: Project? = null,
@@ -43,6 +45,7 @@ class TestSuite(
             TestSuiteDto(
                 this.type,
                 this.name,
+                this.description,
                 this.project,
                 this.propertiesRelativePath,
                 this.testSuiteRepoUrl,

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/TestSuite.kt
@@ -19,7 +19,7 @@ import javax.persistence.ManyToOne
  * @property testSuiteRepoUrl url of the repo with test suites
  * @property description description of the test suite
  */
-@Suppress("USE_DATA_CLASS")
+@Suppress("USE_DATA_CLASS", "LongParameterList")
 @Entity
 class TestSuite(
     @Enumerated(EnumType.STRING)

--- a/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/TestSuite.kt
+++ b/save-cloud-common/src/jvmMain/kotlin/org/cqfn/save/entities/TestSuite.kt
@@ -17,6 +17,7 @@ import javax.persistence.ManyToOne
  * @property dateAdded date and time, when this test suite was added to the project
  * @property propertiesRelativePath location of save.properties file for this test suite, relative to project's root directory
  * @property testSuiteRepoUrl url of the repo with test suites
+ * @property description description of the test suite
  */
 @Suppress("USE_DATA_CLASS")
 @Entity

--- a/save-frontend/build.gradle.kts
+++ b/save-frontend/build.gradle.kts
@@ -82,6 +82,7 @@ val generatedKotlinSrc = kotlin.sourceSets.create("jsGenerated") {
 kotlin.sourceSets.getByName("main").dependsOn(generatedKotlinSrc)
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().forEach {
     it.dependsOn(generateVersionFileTaskProvider)
+    it.inputs.file("$buildDir/generated/src/generated/Versions.kt")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack>().forEach { kotlinWebpack ->

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -41,6 +41,7 @@ import react.router.dom.withRouter
 
 import kotlinx.browser.document
 import kotlinx.html.id
+import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
 
 /**
  * Top-level state of the whole App
@@ -149,7 +150,7 @@ class App : RComponent<PropsWithChildren, AppState>() {
 fun main() {
     kotlinext.js.require("../scss/save-frontend.scss")  // this is needed for webpack to include resource
     kotlinext.js.require("bootstrap")  // this is needed for webpack to include bootstrap
-    library.add(fas, faUser, faCogs, faSignOutAlt, faAngleUp, faCheck, faExclamationTriangle, faTimesCircle)
+    library.add(fas, faUser, faCogs, faSignOutAlt, faAngleUp, faCheck, faExclamationTriangle, faTimesCircle, faQuestionCircle)
     ReactModal.setAppElement(document.getElementById("wrapper") as HTMLElement)  // required for accessibility in react-modal
 
     render(document.getElementById("wrapper")) {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/App.kt
@@ -17,6 +17,7 @@ import org.cqfn.save.frontend.externals.fontawesome.faAngleUp
 import org.cqfn.save.frontend.externals.fontawesome.faCheck
 import org.cqfn.save.frontend.externals.fontawesome.faCogs
 import org.cqfn.save.frontend.externals.fontawesome.faExclamationTriangle
+import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
 import org.cqfn.save.frontend.externals.fontawesome.faSignOutAlt
 import org.cqfn.save.frontend.externals.fontawesome.faTimesCircle
 import org.cqfn.save.frontend.externals.fontawesome.faUser
@@ -41,7 +42,6 @@ import react.router.dom.withRouter
 
 import kotlinx.browser.document
 import kotlinx.html.id
-import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
 
 /**
  * Top-level state of the whole App

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
@@ -6,20 +6,18 @@
 
 package org.cqfn.save.frontend.components.basic
 
+import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
+import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+
 import react.PropsWithChildren
 import react.dom.div
 import react.dom.input
+import react.dom.sup
 import react.fc
 import react.useEffect
 
 import kotlinx.html.InputType
 import kotlinx.html.js.onClickFunction
-import kotlinx.html.style
-import kotlinx.html.title
-import org.cqfn.save.frontend.externals.fontawesome.FontAwesomeIcon
-import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
-import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
-import react.dom.sup
 
 /**
  * Props for ChecboxGrid component
@@ -41,6 +39,7 @@ external interface CheckBoxGridProps : PropsWithChildren {
  * @param tooltips
  * @return an RComponent
  */
+@Suppress("TOO_LONG_FUNCTION", "LongMethod")
 fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGridProps> { props ->
     div {
         options.zip(tooltips).chunked(props.rowSize)

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
@@ -8,6 +8,7 @@ package org.cqfn.save.frontend.components.basic
 
 import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
 import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+import org.cqfn.save.testsuite.TestSuiteDto
 
 import react.PropsWithChildren
 import react.dom.div
@@ -35,34 +36,33 @@ external interface CheckBoxGridProps : PropsWithChildren {
 }
 
 /**
- * @param options list of displayed selectable options
- * @param tooltips
+ * @param suites a list of [TestSuiteDto]s which should be displayed on the grid
  * @return an RComponent
  */
 @Suppress("TOO_LONG_FUNCTION", "LongMethod")
-fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGridProps> { props ->
+fun checkBoxGrid(suites: List<TestSuiteDto>) = fc<CheckBoxGridProps> { props ->
     div {
-        options.zip(tooltips).chunked(props.rowSize)
+        suites.chunked(props.rowSize)
             .forEach { row ->
                 div("row") {
-                    row.forEach { (option, tooltip) ->
+                    row.forEach { suite ->
                         div("col") {
-                            +option
+                            +suite.name
                             sup("tooltip-and-popover") {
                                 fontAwesomeIcon(icon = faQuestionCircle)
                                 attrs["tooltip-placement"] = "top"
-                                attrs["tooltip-title"] = tooltip?.take(100) ?: ""
+                                attrs["tooltip-title"] = suite.description?.take(100) ?: ""
                                 attrs["popover-placement"] = "right"
-                                attrs["popover-title"] = option
-                                attrs["popover-content"] = tooltip ?: ""
+                                attrs["popover-title"] = suite.name
+                                attrs["popover-content"] = suiteDescription(suite)
                             }
                             input(type = InputType.checkBox, classes = "ml-3") {
-                                attrs.defaultChecked = props.selectedOptions.contains(option)
+                                attrs.defaultChecked = props.selectedOptions.contains(suite.name)
                                 attrs.onClickFunction = {
-                                    if (props.selectedOptions.contains(option)) {
-                                        props.selectedOptions.remove(option)
+                                    if (props.selectedOptions.contains(suite.name)) {
+                                        props.selectedOptions.remove(suite.name)
                                     } else {
-                                        props.selectedOptions.add(option)
+                                        props.selectedOptions.add(suite.name)
                                     }
                                 }
                             }
@@ -77,7 +77,8 @@ fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGr
             jQuery(this).popover({
                 placement: jQuery(this).attr("popover-placement"),
                 title: jQuery(this).attr("popover-title"),
-                content: jQuery(this).attr("popover-content")
+                content: jQuery(this).attr("popover-content"),
+                html: true
             }).tooltip({
                 placement: jQuery(this).attr("tooltip-placement"), 
                 title: jQuery(this).attr("tooltip-title")

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
@@ -42,11 +42,13 @@ fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGr
             .forEach { row ->
                 div("row") {
                     row.forEach { (option, tooltip) ->
-                        div("col") {
+                        div("col tooltip-and-popover") {
                             +option
-                            attrs["data-toggle"] = "tooltip"
-                            attrs["data-placement"] = "top"
-                            attrs.title = tooltip ?: ""
+                            attrs["tooltip-placement"] = "top"
+                            attrs["tooltip-title"] = tooltip?.take(100) ?: ""
+                            attrs["popover-placement"] = "right"
+                            attrs["popover-title"] = option
+                            attrs["popover-content"] = tooltip ?: ""
                             input(type = InputType.checkBox, classes = "ml-3") {
                                 attrs.defaultChecked = props.selectedOptions.contains(option)
                                 attrs.onClickFunction = {
@@ -64,6 +66,19 @@ fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGr
     }
     useEffect(emptyList<dynamic>()) {
         js("var jQuery = require(\"jquery\")")
-        js("jQuery('[data-toggle=\"tooltip\"]').tooltip()")
+        js("""jQuery('.tooltip-and-popover').each(function() {
+            jQuery(this).popover({
+                placement: jQuery(this).attr("popover-placement"),
+                title: jQuery(this).attr("popover-title"),
+                content: jQuery(this).attr("popover-content")
+            }).tooltip({
+                placement: jQuery(this).attr("tooltip-placement"), 
+                title: jQuery(this).attr("tooltip-title")
+            }).on('show.bs.popover', function() {
+                jQuery(this).tooltip('hide')
+            }).on('hide.bs.popover', function() {
+                jQuery(this).tooltip('show')
+            })
+        })""")
     }
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
@@ -6,19 +6,15 @@
 
 package org.cqfn.save.frontend.components.basic
 
-import kotlinx.browser.document
 import react.PropsWithChildren
 import react.dom.div
 import react.dom.input
 import react.fc
+import react.useEffect
 
 import kotlinx.html.InputType
 import kotlinx.html.js.onClickFunction
 import kotlinx.html.title
-import org.w3c.dom.Node
-import org.w3c.dom.asList
-import react.useEffect
-import react.useRef
 
 /**
  * Props for ChecboxGrid component
@@ -37,6 +33,7 @@ external interface CheckBoxGridProps : PropsWithChildren {
 
 /**
  * @param options list of displayed selectable options
+ * @param tooltips
  * @return an RComponent
  */
 fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGridProps> { props ->

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
@@ -6,6 +6,7 @@
 
 package org.cqfn.save.frontend.components.basic
 
+import kotlinx.browser.document
 import react.PropsWithChildren
 import react.dom.div
 import react.dom.input
@@ -13,6 +14,11 @@ import react.fc
 
 import kotlinx.html.InputType
 import kotlinx.html.js.onClickFunction
+import kotlinx.html.title
+import org.w3c.dom.Node
+import org.w3c.dom.asList
+import react.useEffect
+import react.useRef
 
 /**
  * Props for ChecboxGrid component
@@ -33,14 +39,17 @@ external interface CheckBoxGridProps : PropsWithChildren {
  * @param options list of displayed selectable options
  * @return an RComponent
  */
-fun checkBoxGrid(options: List<String>) = fc<CheckBoxGridProps> { props ->
+fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGridProps> { props ->
     div {
-        options.chunked(props.rowSize)
-            .forEach { optionsRow ->
+        options.zip(tooltips).chunked(props.rowSize)
+            .forEach { row ->
                 div("row") {
-                    optionsRow.forEach { option ->
+                    row.forEach { (option, tooltip) ->
                         div("col") {
                             +option
+                            attrs["data-toggle"] = "tooltip"
+                            attrs["data-placement"] = "top"
+                            attrs.title = tooltip ?: ""
                             input(type = InputType.checkBox, classes = "ml-3") {
                                 attrs.defaultChecked = props.selectedOptions.contains(option)
                                 attrs.onClickFunction = {
@@ -55,5 +64,9 @@ fun checkBoxGrid(options: List<String>) = fc<CheckBoxGridProps> { props ->
                     }
                 }
             }
+    }
+    useEffect(emptyList<dynamic>()) {
+        js("var jQuery = require(\"jquery\")")
+        js("jQuery('[data-toggle=\"tooltip\"]').tooltip()")
     }
 }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/CheckBoxGrid.kt
@@ -14,7 +14,12 @@ import react.useEffect
 
 import kotlinx.html.InputType
 import kotlinx.html.js.onClickFunction
+import kotlinx.html.style
 import kotlinx.html.title
+import org.cqfn.save.frontend.externals.fontawesome.FontAwesomeIcon
+import org.cqfn.save.frontend.externals.fontawesome.faQuestionCircle
+import org.cqfn.save.frontend.externals.fontawesome.fontAwesomeIcon
+import react.dom.sup
 
 /**
  * Props for ChecboxGrid component
@@ -42,13 +47,16 @@ fun checkBoxGrid(options: List<String>, tooltips: List<String?>) = fc<CheckBoxGr
             .forEach { row ->
                 div("row") {
                     row.forEach { (option, tooltip) ->
-                        div("col tooltip-and-popover") {
+                        div("col") {
                             +option
-                            attrs["tooltip-placement"] = "top"
-                            attrs["tooltip-title"] = tooltip?.take(100) ?: ""
-                            attrs["popover-placement"] = "right"
-                            attrs["popover-title"] = option
-                            attrs["popover-content"] = tooltip ?: ""
+                            sup("tooltip-and-popover") {
+                                fontAwesomeIcon(icon = faQuestionCircle)
+                                attrs["tooltip-placement"] = "top"
+                                attrs["tooltip-title"] = tooltip?.take(100) ?: ""
+                                attrs["popover-placement"] = "right"
+                                attrs["popover-title"] = option
+                                attrs["popover-content"] = tooltip ?: ""
+                            }
                             input(type = InputType.checkBox, classes = "ml-3") {
                                 attrs.defaultChecked = props.selectedOptions.contains(option)
                                 attrs.onClickFunction = {

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/SuiteDescription.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/SuiteDescription.kt
@@ -13,9 +13,12 @@ import org.cqfn.save.testsuite.TestSuiteDto
 fun suiteDescription(suite: TestSuiteDto) =
         """
             <div>
-              ${suite.testSuiteRepoUrl?.let {
-            "<a href=$it>$it</a><br/>"
+                  <ul class="pl-3">
+                  ${suite.testSuiteRepoUrl?.let {
+            "<li><a href=$it>$it</a></li>"
         }}
-              <p>${suite.description ?: ""}</p>
+                <li>${suite.propertiesRelativePath.substringBeforeLast("/save.properties")}</li>
+                </ul>
+                <p>${suite.description ?: ""}</p>
             </div>
         """.trimIndent()

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/SuiteDescription.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/basic/SuiteDescription.kt
@@ -1,0 +1,21 @@
+@file:Suppress("HEADER_MISSING_IN_NON_SINGLE_CLASS_FILE")
+
+package org.cqfn.save.frontend.components.basic
+
+import org.cqfn.save.testsuite.TestSuiteDto
+
+/**
+ * Create a piece of HTML with formatted representation of test suite
+ *
+ * @param suite a test suite to display
+ * @return a string containing HTML
+ */
+fun suiteDescription(suite: TestSuiteDto) =
+        """
+            <div>
+              ${suite.testSuiteRepoUrl?.let {
+            "<a href=$it>$it</a><br/>"
+        }}
+              <p>${suite.description ?: ""}</p>
+            </div>
+        """.trimIndent()

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
@@ -19,7 +19,6 @@ import react.dom.div
 import react.dom.td
 import react.table.columns
 
-import kotlinx.browser.window
 import kotlinx.html.ButtonType
 
 /**

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
@@ -12,13 +12,13 @@ import react.RBuilder
 import react.RComponent
 import react.State
 import react.buildElement
-import react.child
 import react.dom.a
 import react.dom.button
 import react.dom.div
 import react.dom.td
 import react.table.columns
 
+import kotlinx.browser.window
 import kotlinx.html.ButtonType
 
 /**

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -126,7 +126,7 @@ external interface ProjectViewState : State {
 @JsExport
 @OptIn(ExperimentalJsExport::class)
 class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
-    private var testTypesList: List<TestSuiteDto> = emptyList()
+    private var standardTestSuites: List<TestSuiteDto> = emptyList()
     private var pathToProperty: String? = null
     private var gitUrlFromInputField: String? = null
     private val selectedTypes: MutableList<String> = mutableListOf()
@@ -158,7 +158,7 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
             }
             gitDto = post("${window.location.origin}/getGit", headers, jsonProject)
                 .decodeFromJsonString<GitDto>()
-            testTypesList = get("${window.location.origin}/allStandardTestSuites", headers)
+            standardTestSuites = get("${window.location.origin}/allStandardTestSuites", headers)
                 .decodeFromJsonString()
 
             val availableFiles = getFilesList()
@@ -390,7 +390,7 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
                                     setOf("d-none")
                                 }
                                 div("card-body") {
-                                    child(checkBoxGrid(testTypesList.map { it.name })) {
+                                    child(checkBoxGrid(standardTestSuites.map { it.name }, standardTestSuites.map { it.description })) {
                                         attrs.selectedOptions = selectedTypes
                                         attrs.rowSize = TEST_SUITE_ROW
                                     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/ProjectView.kt
@@ -390,7 +390,9 @@ class ProjectView : RComponent<ProjectExecutionRouteProps, ProjectViewState>() {
                                     setOf("d-none")
                                 }
                                 div("card-body") {
-                                    child(checkBoxGrid(standardTestSuites.map { it.name }, standardTestSuites.map { it.description })) {
+                                    child(checkBoxGrid(
+                                        standardTestSuites
+                                    )) {
                                         attrs.selectedOptions = selectedTypes
                                         attrs.rowSize = TEST_SUITE_ROW
                                     }

--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/Icons.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/externals/fontawesome/Icons.kt
@@ -15,3 +15,4 @@ external val faAngleUp: dynamic
 external val faCheck: dynamic
 external val faExclamationTriangle: dynamic
 external val faTimesCircle: dynamic
+external val faQuestionCircle: dynamic

--- a/save-frontend/src/main/resources/scss/save-frontend.scss
+++ b/save-frontend/src/main/resources/scss/save-frontend.scss
@@ -18,3 +18,7 @@
 @import "login.scss";
 @import "error.scss";
 @import "footer.scss";
+
+.tooltip-and-popover {
+  cursor: pointer;
+}

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -304,6 +304,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
                     TestSuiteDto(
                         TestSuiteType.STANDARD,
                         it,
+                        null,
                         project,
                         propertiesRelativePath
                     )

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
@@ -48,6 +48,7 @@ class TestDiscoveringService {
      * @return a list of [TestSuiteDto]s
      * @throws IllegalArgumentException when provided path doesn't point to a valid config file
      */
+    @Suppress("UnsafeCallOnNullableType")
     fun getAllTestSuites(
         project: Project?,
         rootTestConfig: TestConfig,

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
@@ -53,24 +53,24 @@ class TestDiscoveringService {
         rootTestConfig: TestConfig,
         propertiesRelativePath: String,
         testSuiteRepoUrl: String) = rootTestConfig
-            .getAllTestConfigs()
-            .asSequence()
-            .mapNotNull { it.getGeneralConfigOrNull() }
-            .filterNot { it.suiteName == null }
-            .filterNot { it.description == null }
-            .map { config ->
-                // we operate here with suite names from only those TestConfigs, that have General section with suiteName key
-                TestSuiteDto(
-                    project?.let { TestSuiteType.PROJECT } ?: TestSuiteType.STANDARD,
-                    config.suiteName!!,
-                    config.description,
-                    project,
-                    propertiesRelativePath,
-                    testSuiteRepoUrl
-                )
-            }
-            .distinct()
-            .toList()
+        .getAllTestConfigs()
+        .asSequence()
+        .mapNotNull { it.getGeneralConfigOrNull() }
+        .filterNot { it.suiteName == null }
+        .filterNot { it.description == null }
+        .map { config ->
+            // we operate here with suite names from only those TestConfigs, that have General section with suiteName key
+            TestSuiteDto(
+                project?.let { TestSuiteType.PROJECT } ?: TestSuiteType.STANDARD,
+                config.suiteName!!,
+                config.description,
+                project,
+                propertiesRelativePath,
+                testSuiteRepoUrl
+            )
+        }
+        .distinct()
+        .toList()
 
     /**
      * Discover all tests in the project

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringService.kt
@@ -53,13 +53,24 @@ class TestDiscoveringService {
         rootTestConfig: TestConfig,
         propertiesRelativePath: String,
         testSuiteRepoUrl: String) = rootTestConfig
-        .getAllTestConfigs()
-        .mapNotNull { it.getGeneralConfigOrNull()?.suiteName }
-        .map { suiteName ->
-            // we operate here with suite names from only those TestConfigs, that have General section with suiteName key
-            TestSuiteDto(project?.let { TestSuiteType.PROJECT } ?: TestSuiteType.STANDARD, suiteName, project, propertiesRelativePath, testSuiteRepoUrl)
-        }
-        .distinct()
+            .getAllTestConfigs()
+            .asSequence()
+            .mapNotNull { it.getGeneralConfigOrNull() }
+            .filterNot { it.suiteName == null }
+            .filterNot { it.description == null }
+            .map { config ->
+                // we operate here with suite names from only those TestConfigs, that have General section with suiteName key
+                TestSuiteDto(
+                    project?.let { TestSuiteType.PROJECT } ?: TestSuiteType.STANDARD,
+                    config.suiteName!!,
+                    config.description,
+                    project,
+                    propertiesRelativePath,
+                    testSuiteRepoUrl
+                )
+            }
+            .distinct()
+            .toList()
 
     /**
      * Discover all tests in the project

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/DownloadProjectTest.kt
@@ -139,7 +139,7 @@ class DownloadProjectTest(
                 .setHeader("Content-Type", "application/json")
                 .setBody(objectMapper.writeValueAsString(
                     listOf(
-                        TestSuite(TestSuiteType.PROJECT, "", project, LocalDateTime.now(), "save.properties", "https://github.com/cqfn/save.git")
+                        TestSuite(TestSuiteType.PROJECT, "", null, project, LocalDateTime.now(), "save.properties", "https://github.com/cqfn/save.git")
                     )
                 )),
         )
@@ -219,7 +219,7 @@ class DownloadProjectTest(
                 .setHeader("Content-Type", "application/json")
                 .setBody(objectMapper.writeValueAsString(
                     listOf(
-                        TestSuite(TestSuiteType.STANDARD, "stub", project, LocalDateTime.now(), "save.properties", "stub")
+                        TestSuite(TestSuiteType.STANDARD, "stub", null, project, LocalDateTime.now(), "save.properties", "stub")
                     )
                 )),
         )
@@ -294,7 +294,7 @@ class DownloadProjectTest(
                     .setBody(
                         objectMapper.writeValueAsString(
                             listOf(
-                                TestSuite(TestSuiteType.PROJECT, "", project, LocalDateTime.now(), "save.properties")
+                                TestSuite(TestSuiteType.PROJECT, "", null, project, LocalDateTime.now(), "save.properties")
                             )
                         )
                     ),
@@ -357,7 +357,7 @@ class DownloadProjectTest(
                 .setHeader("Content-Type", "application/json")
                 .setBody(objectMapper.writeValueAsString(
                     listOf(
-                        TestSuite(TestSuiteType.PROJECT, "", project, LocalDateTime.now(), "save.properties")
+                        TestSuite(TestSuiteType.PROJECT, "", null, project, LocalDateTime.now(), "save.properties")
                     )
                 )),
         )

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringServiceTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringServiceTest.kt
@@ -59,7 +59,7 @@ class TestDiscoveringServiceTest {
 
         println("Discovered test suites: $testSuites")
         Assertions.assertTrue(testSuites.isNotEmpty())
-        Assertions.assertEquals("autofix", testSuites.first().name)
+        Assertions.assertEquals("Autofix: Smoke Tests", testSuites.first().name)
     }
 
     @Test
@@ -99,7 +99,7 @@ class TestDiscoveringServiceTest {
         }
     }
 
-    private fun createTestSuiteStub(name: String, id: Long) = TestSuite(TestSuiteType.PROJECT, name, null, null, propertiesRelativePath).apply {
+    private fun createTestSuiteStub(name: String, id: Long) = TestSuite(TestSuiteType.PROJECT, name, null, null, null, propertiesRelativePath).apply {
         this.id = id
     }
 }

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringServiceTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringServiceTest.kt
@@ -80,7 +80,7 @@ class TestDiscoveringServiceTest {
             rootTestConfig,
             listOf(
                 createTestSuiteStub("Autofix: Smoke Tests", 1),
-                createTestSuiteStub("autofix", 2),
+                createTestSuiteStub("DocsCheck", 2),
                 createTestSuiteStub("Only Warnings: General", 3),
                 createTestSuiteStub("Autofix and Warn", 4),
                 createTestSuiteStub("Directory: Chapter 1", 5),
@@ -90,7 +90,7 @@ class TestDiscoveringServiceTest {
         )
 
         println("Discovered the following tests: $testDtos")
-        Assertions.assertEquals(10, testDtos.size)
+        Assertions.assertEquals(12, testDtos.size)
         Assertions.assertEquals(testDtos.size, testDtos.map { it.hash + it.filePath + it.testSuiteId }.distinct().size) {
             "Some tests have the same hash/filePath/testSuiteId combination in $testDtos"
         }


### PR DESCRIPTION
### What's done:
* Save description in the DB
* Save only distinct test suites
* Display description on hover on frontend

### TODO:
* [x] Trim description for tooltip, if it's too long
* [x] Add popover with the following info: link to suites repo, name of folder in the repo, full (untrimmed) description
* [x] Add a small `?` sign near every suite name, display info if clicked

![image](https://user-images.githubusercontent.com/23018090/135280605-9d837881-607e-4aed-adc3-f0e2bdb761a4.png)

Closes #247