### PR TITLE
Preprocessor: Don't crash if save.properties doesn't exist in the repo

### DIFF
--- a/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
+++ b/save-frontend/src/main/kotlin/org/cqfn/save/frontend/components/views/CollectionView.kt
@@ -55,7 +55,7 @@ class CollectionView : RComponent<PropsWithChildren, State>() {
                         }
                     }
                 }
-                column(id = "passed", header = "Tests passed") {
+                column(id = "passed", header = "Description") {
                     buildElement {
                         td {
                             a(href = "#/${it.value.owner}/${it.value.name}/history") {

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -187,7 +187,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                     |RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME
                     |RUN chmod +x $executionDir/$SAVE_CLI_EXECUTABLE_NAME
-                    |RUN chmod +x $executionDir/diktat-rules/src/test/resources/test/smoke/src/ktlint
+                    |RUN chmod +x $executionDir/diktat-rules/src/test/resources/test/smoke/ktlint
                 """
         )
         saveAgent.delete()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -188,7 +188,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                     |RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME
                     |RUN chmod +x $executionDir/$SAVE_CLI_EXECUTABLE_NAME
-                    |RUN find "$executionDir/diktat-rules/src/test/resources/test/smoke/ktlint" -type f -exec chmod +x {} \;
+                    |RUN find $executionDir/diktat-rules/src/test/resources/test/smoke/ktlint -type f -exec chmod +x {} \;
                 """
         )
         saveAgent.delete()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -183,6 +183,7 @@ class DockerService(private val configProperties: ConfigProperties) {
             imageName = imageName(execution.id!!),
             baseDir = resourcesPath,
             resourcesPath = executionDir,
+            // TODO: find ktlint this is a temporary workaround link to #277
             runCmd = """RUN apt-get update && env DEBIAN_FRONTEND="noninteractive" apt-get install -y libcurl4-openssl-dev tzdata && rm -rf /var/lib/apt/lists/*
                     |RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -187,6 +187,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                     |RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME
                     |RUN chmod +x $executionDir/$SAVE_CLI_EXECUTABLE_NAME
+                    |RUN chmod +x $executionDir/diktat-rules/src/test/resources/test/smoke/src/ktlint
                 """
         )
         saveAgent.delete()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -187,8 +187,8 @@ class DockerService(private val configProperties: ConfigProperties) {
                     |RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME
                     |RUN chmod +x $executionDir/$SAVE_CLI_EXECUTABLE_NAME
-                    |RUN chmod +x $executionDir/diktat-rules/src/test/resources/test/smoke/ktlint
-                """
+                    |RUN find "$executionDir/diktat-rules/src/test/resources/test/smoke/ktlint" -type f -exec chmod +x {} \;
+                |"""
         )
         saveAgent.delete()
         saveCli.delete()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -188,7 +188,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                     |RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME
                     |RUN chmod +x $executionDir/$SAVE_CLI_EXECUTABLE_NAME
-                    |RUN find $executionDir/diktat-rules/src/test/resources/test/smoke/ktlint -type f -exec chmod +x {} \;
+                    |RUN find . -name $executionDir/diktat-rules/src/test/resources/test/smoke/ktlint -type f -exec chmod +x {} \;
                 """
         )
         saveAgent.delete()

--- a/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
+++ b/save-orchestrator/src/main/kotlin/org/cqfn/save/orchestrator/service/DockerService.kt
@@ -189,7 +189,7 @@ class DockerService(private val configProperties: ConfigProperties) {
                     |RUN chmod +x $executionDir/$SAVE_AGENT_EXECUTABLE_NAME
                     |RUN chmod +x $executionDir/$SAVE_CLI_EXECUTABLE_NAME
                     |RUN find "$executionDir/diktat-rules/src/test/resources/test/smoke/ktlint" -type f -exec chmod +x {} \;
-                |"""
+                """
         )
         saveAgent.delete()
         saveCli.delete()

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -449,11 +449,14 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
     private fun getTestResourcesRootAbsolutePath(propertiesRelativePath: String,
                                                  projectRootRelativePath: String): String {
         // TODO: File should be provided without explicit naming of `save.propeties`, also
-        // TODO: should be consider case, when file not found
         val propertiesFile = File(configProperties.repository, projectRootRelativePath)
             .resolve(propertiesRelativePath)
-        val saveProperties: SaveProperties = decodeFromPropertiesFile<SaveProperties>(propertiesFile)
-            .mergeConfigWithPriorityToThis(defaultConfig())
+        val saveProperties: SaveProperties = if (propertiesFile.exists()) {
+            decodeFromPropertiesFile<SaveProperties>(propertiesFile)
+                .mergeConfigWithPriorityToThis(defaultConfig())
+        } else {
+            defaultConfig()
+        }
         return propertiesFile.parentFile
             .resolve(saveProperties.testFiles!!.firstOrNull() ?: ".")
             .absolutePath

--- a/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
+++ b/save-preprocessor/src/main/kotlin/org/cqfn/save/preprocessor/controllers/DownloadProjectController.kt
@@ -448,7 +448,7 @@ class DownloadProjectController(private val configProperties: ConfigProperties,
     @Suppress("UnsafeCallOnNullableType")
     private fun getTestResourcesRootAbsolutePath(propertiesRelativePath: String,
                                                  projectRootRelativePath: String): String {
-        // TODO: File should be provided without explicit naming of `save.propeties`, also
+        // TODO: File should be provided without explicit naming of `save.propeties`
         val propertiesFile = File(configProperties.repository, projectRootRelativePath)
             .resolve(propertiesRelativePath)
         val saveProperties: SaveProperties = if (propertiesFile.exists()) {

--- a/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringServiceTest.kt
+++ b/save-preprocessor/src/test/kotlin/org/cqfn/save/preprocessor/service/TestDiscoveringServiceTest.kt
@@ -59,7 +59,7 @@ class TestDiscoveringServiceTest {
 
         println("Discovered test suites: $testSuites")
         Assertions.assertTrue(testSuites.isNotEmpty())
-        Assertions.assertEquals("autofix", testSuites.first().name)
+        Assertions.assertEquals("Autofix: Smoke Tests", testSuites.first().name)
     }
 
     @Test


### PR DESCRIPTION
### What's done:
* Added check on save.properties exist
Close #274